### PR TITLE
Re #13: Making sure that log buffer is always power of two (plus some…

### DIFF
--- a/loki-log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/BufferSizeConfigurationTest.java
+++ b/loki-log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/BufferSizeConfigurationTest.java
@@ -1,0 +1,51 @@
+package pl.tkowalcz.tjahzi.log4j2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class BufferSizeConfigurationTest {
+
+    @Container
+    public GenericContainer loki = new GenericContainer("grafana/loki:latest")
+            .withCommand("-config.file=/etc/loki-config.yaml")
+            .withClasspathResourceMapping("loki-config.yaml",
+                    "/etc/loki-config.yaml",
+                    BindMode.READ_ONLY)
+            .waitingFor(
+                    Wait.forHttp("/ready")
+                            .forPort(3100)
+            )
+            .withExposedPorts(3100);
+
+    @Test
+    void shouldSendData() throws URISyntaxException {
+        // Given
+        System.setProperty("loki.host", loki.getHost());
+        System.setProperty("loki.port", loki.getFirstMappedPort().toString());
+
+        URI uri = getClass()
+                .getClassLoader()
+                .getResource("appender-test-with-custom-settings-log4j2-configuration.xml")
+                .toURI();
+
+        // When
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        context.setConfigLocation(uri);
+
+        // Then
+        LokiAppender loki = context.getConfiguration().getAppender("Loki");
+        assertThat(loki.getLoggingSystem().getLogBufferSize()).isEqualTo(64 * 1024 * 1024);
+    }
+}

--- a/loki-log4j2-appender/src/test/resources/appender-test-with-custom-settings-log4j2-configuration.xml
+++ b/loki-log4j2-appender/src/test/resources/appender-test-with-custom-settings-log4j2-configuration.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration status="OFF" shutdownHook="disable" packages="pl.tkowalcz.tjahzi.log4j2">
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Loki"/>
+        </Root>
+    </Loggers>
+
+    <appenders>
+        <Loki name="Loki" bufferSizeMegabytes="64">
+            <host>${sys:loki.host}</host>
+            <port>${sys:loki.port}</port>
+
+            <ThresholdFilter level="ALL"/>
+            <PatternLayout>
+                <Pattern>%X{tid} [%t] %d{MM-dd HH:mm:ss.SSS} %5p %c{1} - %m%n%exception{full}</Pattern>
+            </PatternLayout>
+
+            <Header name="server" value="127.0.0.1"/>
+            <Label name="server" value="127.0.0.1"/>
+        </Loki>
+    </appenders>
+</configuration>

--- a/tjahzi-core/pom.xml
+++ b/tjahzi-core/pom.xml
@@ -68,6 +68,13 @@
             <version>2.13.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.catch-exception</groupId>
+            <artifactId>catch-exception</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- Testcontainers -->
         <dependency>

--- a/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
+++ b/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
@@ -41,4 +41,8 @@ public class LoggingSystem {
             }
         }
     }
+
+    public int getLogBufferSize() {
+        return logBuffer.capacity();
+    }
 }

--- a/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/github/ExceptionWithGitHubReference.java
+++ b/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/github/ExceptionWithGitHubReference.java
@@ -1,0 +1,22 @@
+package pl.tkowalcz.tjahzi.github;
+
+import org.agrona.collections.ArrayUtil;
+
+public class ExceptionWithGitHubReference extends RuntimeException {
+
+    public ExceptionWithGitHubReference(
+            String message,
+            GitHubDocs gitHubDocs,
+            Object... formatArgs
+    ) {
+        super(
+                String.format(
+                        message + ". Check out documentation at %s",
+                        ArrayUtil.add(
+                                formatArgs,
+                                gitHubDocs.getGitHubReference()
+                        )
+                )
+        );
+    }
+}

--- a/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/github/GitHubDocs.java
+++ b/tjahzi-core/src/main/java/pl/tkowalcz/tjahzi/github/GitHubDocs.java
@@ -1,0 +1,20 @@
+package pl.tkowalcz.tjahzi.github;
+
+public enum GitHubDocs {
+
+    LOG_BUFFER_SIZING("https://github.com/tkowalcz/tjahzi/wiki/Log-buffer-sizing");
+
+    private final String gitHubReference;
+
+    GitHubDocs(String gitHubReference) {
+        this.gitHubReference = gitHubReference;
+    }
+
+    public String getGitHubReference() {
+        return gitHubReference;
+    }
+
+    public String getLogMessage() {
+        return String.format("Check out documentation at %s", getGitHubReference());
+    }
+}

--- a/tjahzi-core/src/test/java/pl/tkowalcz/tjahzi/TjahziInitializerTest.java
+++ b/tjahzi-core/src/test/java/pl/tkowalcz/tjahzi/TjahziInitializerTest.java
@@ -1,0 +1,92 @@
+package pl.tkowalcz.tjahzi;
+
+import org.agrona.concurrent.ringbuffer.RingBufferDescriptor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.tkowalcz.tjahzi.TjahziInitializer.MIN_BUFFER_SIZE_BYTES;
+
+class TjahziInitializerTest {
+
+    public static IntStream fromZeroToRingBufferTrailerLength() {
+        return IntStream.range(0, RingBufferDescriptor.TRAILER_LENGTH + 1);
+    }
+
+    public static IntStream powersOfTwo() {
+        return IntStream.range(20, 30) // [1024*1024, 1073741824]
+                .mapToDouble(exponent -> Math.pow(2, exponent))
+                .mapToInt(value -> (int) value);
+    }
+
+    // Given
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, Integer.MIN_VALUE, 10, 80, 150, 246, 1023})
+    void shouldUseMinBufferSizeForInputsSmallerThan1MB(int input) {
+        // When
+        int actual = TjahziInitializer.findNearestPowerOfTwo(input);
+
+        // Then
+        assertThat(actual).isEqualTo(MIN_BUFFER_SIZE_BYTES);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromZeroToRingBufferTrailerLength")
+    void shouldScaleDownToNotExceedInteger_MAX_VALUE(int modifier) {
+        // Given
+        int requestedBufferSize = Integer.MAX_VALUE - modifier;
+        int expected = (int) Math.pow(2, 30);
+
+        // When
+        int actual = TjahziInitializer.findNearestPowerOfTwo(requestedBufferSize);
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnSameValueIfPowerOfTwo() {
+        // Given
+        for (long bufferSize = MIN_BUFFER_SIZE_BYTES; bufferSize < Integer.MAX_VALUE; bufferSize <<= 1) {
+            // When
+            int actual = TjahziInitializer.findNearestPowerOfTwo((int) bufferSize);
+
+            // Then
+            assertThat(actual)
+                    .isEqualTo(bufferSize);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("powersOfTwo")
+    void shouldRoundToNearestPowerOfTwo(int power) {
+        // Given
+        int bufferSizeBelowPower = power - 1;
+        int bufferSize = power;
+        int bufferSizeAbovePower = power + 1;
+
+        if (bufferSizeBelowPower <= MIN_BUFFER_SIZE_BYTES) {
+            // Skip this part of check as it would pass invalid value to test method
+            bufferSizeBelowPower = power;
+        }
+
+        // When
+        int actualBufferSizeBelowPower = TjahziInitializer.findNearestPowerOfTwo(bufferSizeBelowPower);
+        int actualBufferSize = TjahziInitializer.findNearestPowerOfTwo(bufferSize);
+        int actualBufferSizeAbovePower = TjahziInitializer.findNearestPowerOfTwo(bufferSizeAbovePower);
+
+        // Then
+        assertThat(actualBufferSizeBelowPower)
+                .isEqualTo(power);
+
+        assertThat(actualBufferSize)
+                .isEqualTo(power);
+
+        assertThat(actualBufferSizeAbovePower)
+                .isEqualTo(power << 1);
+    }
+}


### PR DESCRIPTION
… bytes for ring buffer bookkeeping). If input is not power of two then we will use nearest power that is greater than provided value. Minimum value is 1MB while maximum is 1GB.