### PR TITLE
getLogBufferByteRemainsSize method

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
@@ -55,4 +55,8 @@ public class LoggingSystem {
     public int getLogBufferSize() {
         return logBuffer.capacity();
     }
+
+    public int getLogBufferByteRemainsSize() {
+        return logBuffer.size();
+    }
 }

--- a/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/BufferSizeConfigurationTest.java
+++ b/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/BufferSizeConfigurationTest.java
@@ -26,6 +26,7 @@ class BufferSizeConfigurationTest {
         // Then
         LokiAppender loki = context.getConfiguration().getAppender("Loki");
         assertThat(loki.getLoggingSystem().getLogBufferSize()).isEqualTo(32 * 1024 * 1024);
+        assertThat(loki.getLoggingSystem().getLogBufferByteRemainsSize() == 0);
     }
 
     @Test
@@ -43,5 +44,6 @@ class BufferSizeConfigurationTest {
         // Then
         LokiAppender loki = context.getConfiguration().getAppender("Loki");
         assertThat(loki.getLoggingSystem().getLogBufferSize()).isEqualTo(64 * 1024 * 1024);
+        assertThat(loki.getLoggingSystem().getLogBufferByteRemainsSize() == 0);
     }
 }


### PR DESCRIPTION
Hello @tkowalcz! We need this method for determining how much byte remains to send. Later I want to implement drain on stop functionality, because right now we lost some part of logs when server shutdown.