### PR TITLE
adds the logger_name and thread_name labels for logback

### DIFF
--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LabelFactory.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LabelFactory.java
@@ -17,15 +17,21 @@ public class LabelFactory {
     private final ContextAware internalLogger;
 
     private final String logLevelLabel;
+    private final String loggerNameLabel;
+    private final String threadNameLabel;
     private final Label[] labels;
 
     public LabelFactory(
             ContextAware internalLogger,
             String logLevelLabel,
+            String loggerNameLabel,
+            String threadNameLabel,
             Label... labels
     ) {
         this.internalLogger = internalLogger;
         this.logLevelLabel = logLevelLabel;
+        this.loggerNameLabel = loggerNameLabel;
+        this.threadNameLabel = threadNameLabel;
         this.labels = labels;
     }
 
@@ -36,9 +42,34 @@ public class LabelFactory {
 
     public String validateLogLevelLabel(HashMap<String, String> existingLabels) {
         if (logLevelLabel != null) {
-            return validateLogLevelLabelAgainst(
+            return validatePredefinedLabelAgainst(
                     existingLabels,
-                    logLevelLabel
+                    logLevelLabel,
+                    "log level label"
+            );
+        }
+
+        return null;
+    }
+
+    public String validateLoggerNameLabel(HashMap<String, String> existingLabels) {
+        if (loggerNameLabel != null) {
+            return validatePredefinedLabelAgainst(
+                    existingLabels,
+                    loggerNameLabel,
+                    "logger name label"
+            );
+        }
+
+        return null;
+    }
+
+    public String validateThreadNameLabel(HashMap<String, String> existingLabels) {
+        if (threadNameLabel != null) {
+            return validatePredefinedLabelAgainst(
+                    existingLabels,
+                    threadNameLabel,
+                    "thread name label"
             );
         }
 
@@ -89,15 +120,17 @@ public class LabelFactory {
         return lokiLabels;
     }
 
-    private String validateLogLevelLabelAgainst(
+    private String validatePredefinedLabelAgainst(
             Map<String, String> existingLabels,
-            String logLevelLabel
+            String predefinedLabel,
+            String predefinedLabelDescription
     ) {
-        if (!Label.hasValidName(logLevelLabel)) {
+        if (!Label.hasValidName(predefinedLabel)) {
             internalLogger.addWarn(
                     String.format(
-                            "Ignoring log level label '%s' - contains invalid characters. %s\n",
-                            logLevelLabel,
+                            "Ignoring %s '%s' - contains invalid characters. %s\n",
+                            predefinedLabelDescription,
+                            predefinedLabel,
                             GitHubDocs.LABEL_NAMING.getLogMessage()
                     )
             );
@@ -105,15 +138,16 @@ public class LabelFactory {
             return null;
         }
 
-        if (existingLabels.remove(logLevelLabel) != null) {
+        if (existingLabels.remove(predefinedLabel) != null) {
             internalLogger.addWarn(
                     String.format(
-                            "Ignoring log level label '%s' - conflicts with label defined in configuration.\n",
-                            logLevelLabel
+                            "Ignoring %s '%s' - conflicts with label defined in configuration.\n",
+                            predefinedLabelDescription,
+                            predefinedLabel
                     )
             );
         }
 
-        return logLevelLabel;
+        return predefinedLabel;
     }
 }

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
@@ -26,6 +26,8 @@ public class LokiAppender extends LokiAppenderConfigurator {
 
     private TjahziLogger logger;
     private String logLevelLabel;
+    private String loggerNameLabel;
+    private String threadNameLabel;
     private List<String> mdcLogLabels;
 
     private MutableMonitoringModuleWrapper monitoringModuleWrapper;
@@ -62,11 +64,15 @@ public class LokiAppender extends LokiAppenderConfigurator {
     @Override
     protected void append(ILoggingEvent event) {
         String logLevel = event.getLevel().toString();
+        String loggerName = event.getLoggerName();
+        String threadName = event.getThreadName();
         ByteBuffer logLine = actualEncoder.apply(event);
         Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
-
+        
         LabelSerializer labelSerializer = LabelSerializers.threadLocal();
         appendLogLabel(labelSerializer, logLevel);
+        appendLoggerLabel(labelSerializer, loggerName);
+        appendThreadLabel(labelSerializer, threadName);
         appendMdcLogLabels(labelSerializer, mdcPropertyMap);
 
         logger.log(
@@ -83,6 +89,17 @@ public class LokiAppender extends LokiAppenderConfigurator {
         }
     }
 
+    private void appendLoggerLabel(LabelSerializer labelSerializer, String loggerName) {
+         if (loggerNameLabel != null) {
+            labelSerializer.appendLabel(loggerNameLabel, loggerName);
+        }
+    }
+
+    private void appendThreadLabel(LabelSerializer labelSerializer, String threadName) {
+        if (threadNameLabel != null) {
+            labelSerializer.appendLabel(threadNameLabel, threadName);
+        }
+    }
     @SuppressWarnings("ForLoopReplaceableByForEach") // Allocator goes brrrr
     private void appendMdcLogLabels(LabelSerializer serializer,
                                     Map<String, String> mdcPropertyMap) {
@@ -112,6 +129,8 @@ public class LokiAppender extends LokiAppenderConfigurator {
         LokiAppenderFactory lokiAppenderFactory = new LokiAppenderFactory(this);
         loggingSystem = lokiAppenderFactory.createAppender();
         logLevelLabel = lokiAppenderFactory.getLogLevelLabel();
+        loggerNameLabel = lokiAppenderFactory.getLoggerNameLabel();
+        threadNameLabel = lokiAppenderFactory.getThreadNameLabel();
         mdcLogLabels = lokiAppenderFactory.getMdcLogLabels();
         monitoringModuleWrapper = lokiAppenderFactory.getMonitoringModuleWrapper();
 

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderConfigurator.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderConfigurator.java
@@ -32,6 +32,8 @@ public abstract class LokiAppenderConfigurator extends UnsynchronizedAppenderBas
     private boolean useOffHeapBuffer = true;
 
     private String logLevelLabel;
+    private String loggerNameLabel;
+    private String threadNameLabel;
     private final List<String> mdcLogLabels = new ArrayList<>();
 
     private long batchSize = 10_2400;
@@ -154,6 +156,22 @@ public abstract class LokiAppenderConfigurator extends UnsynchronizedAppenderBas
 
     public void setLogLevelLabel(String logLevelLabel) {
         this.logLevelLabel = logLevelLabel;
+    }
+
+    public String getLoggerNameLabel() {
+        return loggerNameLabel;
+    }
+
+    public void setLoggerNameLabel(String loggerNameLabel) {
+        this.loggerNameLabel = loggerNameLabel;
+    }
+
+    public String getThreadNameLabel() {
+        return threadNameLabel;
+    }
+
+    public void setThreadNameLabel(String threadNameLabel) {
+        this.threadNameLabel = threadNameLabel;
     }
 
     public void setBatchSize(long batchSize) {

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
@@ -20,6 +20,8 @@ public class LokiAppenderFactory {
 
     private final HashMap<String, String> lokiLabels;
     private final String logLevelLabel;
+    private final String loggerNameLabel;
+    private final String threadNameLabel;
     private final List<String> mdcLogLabels;
     private final MutableMonitoringModuleWrapper monitoringModuleWrapper;
 
@@ -29,11 +31,15 @@ public class LokiAppenderFactory {
         LabelFactory labelFactory = new LabelFactory(
                 configurator,
                 configurator.getLogLevelLabel(),
+                configurator.getLoggerNameLabel(),
+                configurator.getThreadNameLabel(),
                 configurator.getLabels().toArray(new Label[0])
         );
 
         lokiLabels = labelFactory.convertLabelsDroppingInvalid();
         logLevelLabel = labelFactory.validateLogLevelLabel(lokiLabels);
+        loggerNameLabel = labelFactory.validateLoggerNameLabel(lokiLabels);
+        threadNameLabel = labelFactory.validateThreadNameLabel(lokiLabels);
         mdcLogLabels = configurator.getMdcLogLabels();
         monitoringModuleWrapper = new MutableMonitoringModuleWrapper();
     }
@@ -94,6 +100,14 @@ public class LokiAppenderFactory {
 
     public String getLogLevelLabel() {
         return logLevelLabel;
+    }
+
+    public String getLoggerNameLabel() {
+        return loggerNameLabel;
+    }
+
+    public String getThreadNameLabel() {
+        return threadNameLabel;
     }
 
     public MutableMonitoringModuleWrapper getMonitoringModuleWrapper() {

--- a/logback-appender/src/test/java/pl/tkowalcz/tjahzi/logback/LogLevelLabelConfigurationTest.java
+++ b/logback-appender/src/test/java/pl/tkowalcz/tjahzi/logback/LogLevelLabelConfigurationTest.java
@@ -36,8 +36,11 @@ class LogLevelLabelConfigurationTest extends IntegrationTest {
         LoggerContext context = loadConfig("appender-test-with-log-label-set.xml");
 
         // When
+        String originalThreadName=Thread.currentThread().getName();
+        Thread.currentThread().setName("appender-test-with-log-label-set.xml");
         Logger logger = context.getLogger(LogLevelLabelConfigurationTest.class);
         logger.info("Test");
+        Thread.currentThread().setName(originalThreadName);
 
         // Then
         assertThat(loki)
@@ -46,6 +49,8 @@ class LogLevelLabelConfigurationTest extends IntegrationTest {
                         .body("status", equalTo("success"))
                         .body("data.result.size()", equalTo(1))
                         .body("data.result[0].stream.log_level", equalTo("INFO"))
+                        .body("data.result[0].stream.logger_name", equalTo("pl.tkowalcz.tjahzi.logback.LogLevelLabelConfigurationTest"))
+                        .body("data.result[0].stream.thread_name", equalTo("appender-test-with-log-label-set.xml"))
                 );
     }
 }

--- a/logback-appender/src/test/resources/appender-test-with-log-label-set.xml
+++ b/logback-appender/src/test/resources/appender-test-with-log-label-set.xml
@@ -15,7 +15,12 @@
         <logLevelLabel>
             log_level
         </logLevelLabel>
-
+        <loggerNameLabel>
+            logger_name
+        </loggerNameLabel>
+        <threadNameLabel>
+            thread_name
+        </threadNameLabel>
         <label>
             <name>test</name>
             <value>shouldSendLogLevelAsConfigured</value>

--- a/logback-appender/src/test/resources/logback-configuration.xml
+++ b/logback-appender/src/test/resources/logback-configuration.xml
@@ -18,6 +18,12 @@
         <logLevelLabel>
             log_level
         </logLevelLabel>
+        <loggerNameLabel>
+            logger_name
+        </loggerNameLabel>
+        <threadNameLabel>
+            thread_name
+        </threadNameLabel>
     </appender>
 
     <root level="debug">


### PR DESCRIPTION
This is a proposal to add logger_name and thread_name as first-class labels in logback appender which fixes #107 

A possible alternative with less impact but more hackish could be to include these values as members of the mdc properties ,for example:
```
    @Override
    protected void append(ILoggingEvent event) {
        String logLevel = event.getLevel().toString();
        ByteBuffer logLine = actualEncoder.apply(event);
        Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
        
        mdcPropertyMap.put("logback_logger_name", event.getLoggerName());
        mdcPropertyMap.put("logback_thread_name", event.getThreadName());
        
        LabelSerializer labelSerializer = LabelSerializers.threadLocal();
        appendLogLabel(labelSerializer, logLevel);
        appendMdcLogLabels(labelSerializer, mdcPropertyMap);

        logger.log(
                event.getTimeStamp(),
                0L,
                labelSerializer,
                logLine
        );
    }
```
