### PR TITLE
Change way of accessing hostname

### DIFF
--- a/log4j2-appender/README.md
+++ b/log4j2-appender/README.md
@@ -39,7 +39,7 @@ Log4j2 appender seemed like a good first.
         <Pattern>%X{tid} [%t] %d{MM-dd HH:mm:ss.SSS} %5p %c{1} - %m%n%exception{full}</Pattern>
     </PatternLayout>
 
-    <Label name="server" value="${sys:hostname}"/>
+    <Label name="server" value="${hostName}"/>
 </Loki>
 ```
 


### PR DESCRIPTION
The `${sys:hostname}` variable is not always set. However, Log4J2 has a default variable called `hostName` that is always available. This change adapts the example configuration to use the default variable.

See also: https://logging.apache.org/log4j/2.x/manual/configuration.html#AutomaticConfiguration

> ## Default Properties
> [...]
>
> The default map is pre-populated with a value for "hostName" that is the current system's host name or IP address [...]