### PR TITLE
Update log4j to 2.25.4 (CVE-2026-34477/34478/34480, CVE-2025-68161)

### DIFF
--- a/log4j2-appender-nodep/pom.xml
+++ b/log4j2-appender-nodep/pom.xml
@@ -23,6 +23,13 @@
             <artifactId>log4j2-appender</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.25.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/log4j2-appender/pom.xml
+++ b/log4j2-appender/pom.xml
@@ -22,7 +22,8 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.4</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/LokiAppenderBuilder.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/LokiAppenderBuilder.java
@@ -38,27 +38,34 @@ public class LokiAppenderBuilder<B extends LokiAppenderBuilder<B>> extends Abstr
     private static final int BYTES_IN_KILOBYTE = 1024;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String url;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String logEndpoint;
 
     @PluginBuilderAttribute
     private String host;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int port;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private boolean useSSL;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private boolean useDaemonThreads;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String username;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String password;
 
     @PluginBuilderAttribute
@@ -68,42 +75,55 @@ public class LokiAppenderBuilder<B extends LokiAppenderBuilder<B>> extends Abstr
     private int readTimeoutMillis = 60_000;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int maxRetries = 3;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int bufferSizeMegabytes = 32;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String logLevelLabel;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private long batchSize = 10_2400;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private long batchWait = 5;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private long logShipperWakeupIntervalMillis = 10;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int shutdownTimeoutSeconds = 10;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int maxLogLineSizeKilobytes = 10;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private int maxRequestsInFlight = 100;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private boolean verbose;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String truststorePath;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String truststorePassword;
 
     @PluginBuilderAttribute
+    @SuppressWarnings("log4j.public.setter")
     private String truststoreType;
 
     @PluginElement("Headers")

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.13.3</version>
+                <version>2.25.4</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Fixes #163.

## Changes

- **log4j-core 2.24.3 → 2.25.4** in `log4j2-appender`. 2.25.4 fixes CVE-2026-34477 (SSL hostname verification bypass), CVE-2026-34478 (Rfc5424Layout log injection), CVE-2026-34480 (XmlLayout invalid XML) and completes the fix for CVE-2025-68161.
- **log4j-core scope changed to `provided`.** Appender consumers by definition run their own log4j, so tjahzi should not pin a log4j version into their dependency tree. With this change the published `log4j2-appender-nodep` pom no longer declares any log4j dependency at all — which is what security scanners were flagging against 0.9.42.
- `log4j2-appender-nodep` now declares `log4j-core` explicitly (also `provided`) since it recompiles the appender sources and no longer inherits it transitively.
- Managed test dependency `log4j-slf4j-impl` 2.13.3 → 2.25.4 so tests don't mix log4j-api 2.25.x with a 2.13.x binding.

## Verification

- `mvn package` of `log4j2-appender` and `log4j2-appender-nodep` succeeds.
- The nodep shaded jar contains no `org/apache/logging` classes and its dependency-reduced pom has no log4j dependency.
- Full test confirmation delegated to CI.
