### PR TITLE
[0.9.x] Include non-default port in Host header of push requests

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/NettyHttpClient.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/NettyHttpClient.java
@@ -19,6 +19,8 @@ public class NettyHttpClient implements Closeable {
     private final HttpHeaders headers;
     private final HttpConnection lokiConnection;
 
+    private final String hostHeader;
+
     private final Snappy snappy = new Snappy();
 
     public NettyHttpClient(
@@ -30,6 +32,7 @@ public class NettyHttpClient implements Closeable {
 
         this.headers = HttpHeadersFactory.createHeaders(clientConfiguration, additionalHeaders);
         this.lokiConnection = new HttpConnection(clientConfiguration, monitoringModule);
+        this.hostHeader = buildHostHeader(clientConfiguration);
     }
 
     public void log(ByteBuf dataBuffer) {
@@ -44,9 +47,23 @@ public class NettyHttpClient implements Closeable {
                 .add(headers)
                 .set(HttpHeaderNames.CONTENT_TYPE, PROTOBUF_MIME_TYPE)
                 .set(HttpHeaderNames.CONTENT_LENGTH, dataBuffer.readableBytes())
-                .set(HttpHeaderNames.HOST, clientConfiguration.getHost());
+                .set(HttpHeaderNames.HOST, hostHeader);
 
         lokiConnection.execute(request);
+    }
+
+    private static String buildHostHeader(ClientConfiguration clientConfiguration) {
+        int port = clientConfiguration.getPort();
+
+        boolean isDefaultPort = clientConfiguration.isUseSSL()
+                ? port == ConnectionParamsFactory.HTTPS_PORT
+                : port == ConnectionParamsFactory.HTTP_PORT;
+
+        if (isDefaultPort) {
+            return clientConfiguration.getHost();
+        }
+
+        return clientConfiguration.getHost() + ":" + port;
     }
 
     @Override

--- a/core/src/test/java/pl/tkowalcz/tjahzi/HeadersTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/HeadersTest.java
@@ -231,7 +231,62 @@ class HeadersTest {
                                 postRequestedFor(urlMatching("/loki/api/v1/push"))
                                         .withHeader("content-type", matching("application/x-protobuf"))
                                         .withHeader("content-length", matching("[4-5][0-9]"))
-                                        .withHeader("host", matching("localhost"))
+                                        .withHeader("host", matching("localhost:[0-9]+"))
+                        ));
+    }
+
+    @Test
+    void shouldIncludeNonDefaultPortInHostHeader() {
+        // Given
+        wireMockServer.stubFor(
+                post(urlEqualTo("/loki/api/v1/push"))
+                        .willReturn(
+                                aResponse().withStatus(200)
+                        ));
+
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .withConnectionTimeoutMillis(10_000)
+                .withHost("localhost")
+                .withPort(wireMockServer.port())
+                .withMaxRetries(1)
+                .build();
+
+        NettyHttpClient httpClient = HttpClientFactory.defaultFactory()
+                .getHttpClient(
+                        clientConfiguration,
+                        monitoringModule
+                );
+
+        loggingSystem = initializer.createLoggingSystem(
+                httpClient,
+                monitoringModule,
+                Map.of(),
+                0,
+                0,
+                1024 * 1024,
+                250,
+                10_000,
+                false
+        );
+        loggingSystem.start();
+
+        // When
+        TjahziLogger logger = loggingSystem.createLogger();
+        logger.log(
+                System.currentTimeMillis(),
+                0,
+                labelSerializer,
+                new LabelSerializer(),
+                ByteBuffer.wrap("Test".getBytes())
+        );
+
+        // Then
+        await()
+                .atMost(Durations.FIVE_SECONDS)
+                .untilAsserted(() ->
+                        wireMockServer.verify(
+                                postRequestedFor(urlMatching("/loki/api/v1/push"))
+                                        .withHeader("host", equalTo("localhost:" + wireMockServer.port()))
                         ));
     }
 }


### PR DESCRIPTION
Backport of #165 to the 0.9.x release train (cherry-pick, applied cleanly). Addresses #157.

See #165 for full description: Host header now includes `:port` unless it is the scheme default (80/http, 443/https), per RFC 7230 §5.4. Includes WireMock regression test.

Intended to ship as 0.9.43.
