### PR TITLE
Fix HTTP client robustness: request timeout, 429/5xx retry, backoff reset, wedged connections

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/BlockingRetry.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/BlockingRetry.java
@@ -45,6 +45,8 @@ class BlockingRetry implements Retry {
             try {
                 Thread.sleep(strategy.getAsLong(), 0);
             } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+                failureAction.run();
                 return;
             }
 

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/BootstrapUtil.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/BootstrapUtil.java
@@ -50,7 +50,8 @@ public class BootstrapUtil {
                                 clientConfiguration.getHost(),
                                 clientConfiguration.getPort(),
                                 clientConfiguration.getRequestTimeoutMillis(),
-                                clientConfiguration.getMaxRequestsInFlight()
+                                clientConfiguration.getMaxRequestsInFlight(),
+                                clientConfiguration.getMaxRetries()
                         )
                 )
                 .remoteAddress(

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/ClientConfigurationBuilder.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/ClientConfigurationBuilder.java
@@ -17,7 +17,7 @@ public class ClientConfigurationBuilder {
 
     public static final int DEFAULT_MAX_REQUESTS_IN_FLIGHT = 100;
 
-    public static final int DEFAULT_MAX_RETRIES = 0;
+    public static final int DEFAULT_MAX_RETRIES = 3;
 
     private String logEndpoint;
 

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/EventLoopGroupRetry.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/EventLoopGroupRetry.java
@@ -45,4 +45,8 @@ class EventLoopGroupRetry implements Retry, Runnable {
                 TimeUnit.MILLISECONDS
         );
     }
+
+    public void reset() {
+        strategy.reset();
+    }
 }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/ExponentialBackoffStrategy.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/ExponentialBackoffStrategy.java
@@ -4,6 +4,7 @@ import java.util.function.LongSupplier;
 
 public class ExponentialBackoffStrategy implements LongSupplier {
 
+    private final long initialBackoffMillis;
     private final long maximumBackoffMillis;
     private final double multiplier;
 
@@ -14,6 +15,7 @@ public class ExponentialBackoffStrategy implements LongSupplier {
             long maximumBackoffMillis,
             double multiplier
     ) {
+        this.initialBackoffMillis = initialBackoffMillis;
         this.maximumBackoffMillis = maximumBackoffMillis;
         this.multiplier = multiplier;
 
@@ -26,6 +28,10 @@ public class ExponentialBackoffStrategy implements LongSupplier {
 
         nextBackoff = (long) Math.min(nextBackoff * multiplier, maximumBackoffMillis);
         return result;
+    }
+
+    public void reset() {
+        nextBackoff = initialBackoffMillis;
     }
 
     public static ExponentialBackoffStrategy withDefault() {

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpClientInitializer.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpClientInitializer.java
@@ -10,13 +10,14 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleStateHandler;
 import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 
+import java.util.concurrent.TimeUnit;
+
 class HttpClientInitializer extends ChannelInitializer<Channel> {
 
     private static final int BYTES_IN_MEGABYTE = 1024 * 1024;
     private static final int MAX_CONTENT_LENGTH = 10 * BYTES_IN_MEGABYTE;
 
     private final MonitoringModule monitoringModule;
-    private final RequestAndResponseHandler responseHandler;
 
     private final SslContext sslContext;
 
@@ -24,6 +25,7 @@ class HttpClientInitializer extends ChannelInitializer<Channel> {
     private final int port;
     private final int requestTimeoutMillis;
     private final int maxRequestsInFlight;
+    private final int maxRetries;
 
     HttpClientInitializer(
             MonitoringModule monitoringModule,
@@ -31,16 +33,17 @@ class HttpClientInitializer extends ChannelInitializer<Channel> {
             String host,
             int port,
             int requestTimeoutMillis,
-            int maxRequestsInFlight
+            int maxRequestsInFlight,
+            int maxRetries
     ) {
         this.monitoringModule = monitoringModule;
-        this.responseHandler = new RequestAndResponseHandler(monitoringModule);
         this.sslContext = sslContext;
         this.host = host;
         this.port = port;
 
         this.requestTimeoutMillis = requestTimeoutMillis;
         this.maxRequestsInFlight = maxRequestsInFlight;
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -49,7 +52,8 @@ class HttpClientInitializer extends ChannelInitializer<Channel> {
         p.addLast(new IdleStateHandler(
                         requestTimeoutMillis,
                         0,
-                        60
+                        0,
+                        TimeUnit.MILLISECONDS
                 )
         );
 
@@ -66,6 +70,6 @@ class HttpClientInitializer extends ChannelInitializer<Channel> {
                         maxRequestsInFlight
                 )
         );
-        p.addLast(responseHandler);
+        p.addLast(new RequestAndResponseHandler(monitoringModule, maxRetries));
     }
 }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
@@ -1,6 +1,7 @@
 package pl.tkowalcz.tjahzi.http;
 
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -15,11 +16,19 @@ public class HttpConnection implements Closeable {
     private final MonitoringModule monitoringModule;
 
     private final NioEventLoopGroup group;
+    private final ChannelFutureListener writeFailureListener;
     private volatile ChannelFuture lokiConnection;
 
     public HttpConnection(ClientConfiguration clientConfiguration, MonitoringModule monitoringModule) {
         this.clientConfiguration = clientConfiguration;
         this.monitoringModule = monitoringModule;
+
+        this.writeFailureListener = future -> {
+            if (!future.isSuccess()) {
+                monitoringModule.incrementFailedHttpRequests();
+                monitoringModule.addPipelineError(future.cause());
+            }
+        };
 
         ThreadFactory threadFactory = new DefaultThreadFactory("tjahzi-worker", true);
         this.group = new NioEventLoopGroup(1, threadFactory);
@@ -79,12 +88,7 @@ public class HttpConnection implements Closeable {
             stableReference
                     .channel()
                     .writeAndFlush(request)
-                    .addListener((ChannelFuture future) -> {
-                        if (!future.isSuccess()) {
-                            monitoringModule.incrementFailedHttpRequests();
-                            monitoringModule.addPipelineError(future.cause());
-                        }
-                    });
+                    .addListener(writeFailureListener);
         } else {
             retry.retry();
         }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
@@ -34,7 +34,7 @@ public class HttpConnection implements Closeable {
         recreateConnection(retry);
     }
 
-    private void recreateConnection(Retry retry) {
+    private void recreateConnection(EventLoopGroupRetry retry) {
         lokiConnection = BootstrapUtil.initConnection(
                 group,
                 clientConfiguration,
@@ -43,6 +43,8 @@ public class HttpConnection implements Closeable {
 
         lokiConnection.addListener((ChannelFuture future) -> {
             if (future.isSuccess()) {
+                retry.reset();
+
                 future
                         .channel()
                         .closeFuture()
@@ -74,7 +76,15 @@ public class HttpConnection implements Closeable {
 
         stableReference.awaitUninterruptibly();
         if (stableReference.isSuccess() && stableReference.channel().isActive()) {
-            stableReference.channel().writeAndFlush(request);
+            stableReference
+                    .channel()
+                    .writeAndFlush(request)
+                    .addListener((ChannelFuture future) -> {
+                        if (!future.isSuccess()) {
+                            monitoringModule.incrementFailedHttpRequests();
+                            monitoringModule.addPipelineError(future.cause());
+                        }
+                    });
         } else {
             retry.retry();
         }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandler.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandler.java
@@ -1,32 +1,55 @@
 package pl.tkowalcz.tjahzi.http;
 
 import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.util.ReferenceCountUtil;
 import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 
 import java.nio.charset.Charset;
+import java.util.ArrayDeque;
+import java.util.concurrent.TimeUnit;
 
-@ChannelHandler.Sharable
 class RequestAndResponseHandler extends ChannelDuplexHandler {
 
     private final MonitoringModule monitoringModule;
+    private final int maxRetries;
 
-    RequestAndResponseHandler(MonitoringModule monitoringModule) {
+    private final ArrayDeque<PendingRequest> inFlight = new ArrayDeque<>();
+    private final ExponentialBackoffStrategy retryBackoff = ExponentialBackoffStrategy.withDefault();
+
+    private PendingRequest resending;
+
+    RequestAndResponseHandler(MonitoringModule monitoringModule, int maxRetries) {
         this.monitoringModule = monitoringModule;
+        this.maxRetries = maxRetries;
     }
 
     @Override
     public void write(ChannelHandlerContext ctx, Object object, ChannelPromise promise) throws Exception {
         if (object instanceof FullHttpRequest) {
-            int payloadSize = ((FullHttpRequest) object).content().readableBytes();
-            monitoringModule.incrementSentHttpRequests(payloadSize);
+            FullHttpRequest request = (FullHttpRequest) object;
+            monitoringModule.incrementSentHttpRequests(request.content().readableBytes());
+
+            if (resending != null) {
+                inFlight.addLast(resending);
+                resending = null;
+            } else {
+                inFlight.addLast(
+                        new PendingRequest(
+                                request.retainedDuplicate(),
+                                maxRetries
+                        )
+                );
+            }
         }
 
         super.write(ctx, object, promise);
@@ -35,6 +58,7 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object object) {
         FullHttpResponse msg = (FullHttpResponse) object;
+        PendingRequest pendingRequest = inFlight.pollFirst();
 
         monitoringModule.incrementHttpResponses();
         if (msg.status().codeClass() != HttpStatusClass.SUCCESS) {
@@ -42,6 +66,14 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
                     msg.status().code(),
                     msg.content().toString(Charset.defaultCharset())
             );
+
+            handleFailedRequest(ctx, msg.status(), pendingRequest);
+        } else {
+            retryBackoff.reset();
+
+            if (pendingRequest != null) {
+                pendingRequest.release();
+            }
         }
 
         if (!HttpUtil.isKeepAlive(msg)) {
@@ -52,12 +84,87 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
     }
 
     @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object event) throws Exception {
+        if (event instanceof IdleStateEvent
+                && ((IdleStateEvent) event).state() == IdleState.READER_IDLE) {
+            if (!inFlight.isEmpty()) {
+                monitoringModule.addPipelineError(ReadTimeoutException.INSTANCE);
+                ctx.close();
+            }
+
+            return;
+        }
+
+        super.userEventTriggered(ctx, event);
+    }
+
+    @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         monitoringModule.addPipelineError(cause);
+        ctx.close();
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
         monitoringModule.incrementChannelInactive();
+
+        while (!inFlight.isEmpty()) {
+            monitoringModule.incrementFailedHttpRequests();
+            inFlight.pollFirst().release();
+        }
+    }
+
+    private void handleFailedRequest(
+            ChannelHandlerContext ctx,
+            HttpResponseStatus status,
+            PendingRequest pendingRequest
+    ) {
+        if (pendingRequest == null) {
+            return;
+        }
+
+        if (isRetriable(status) && pendingRequest.retriesLeft > 0) {
+            pendingRequest.retriesLeft--;
+            monitoringModule.incrementRetriedHttpRequests();
+
+            ctx.channel().eventLoop().schedule(
+                    () -> resend(ctx, pendingRequest),
+                    retryBackoff.getAsLong(),
+                    TimeUnit.MILLISECONDS
+            );
+        } else {
+            pendingRequest.release();
+        }
+    }
+
+    private void resend(ChannelHandlerContext ctx, PendingRequest pendingRequest) {
+        if (!ctx.channel().isActive()) {
+            monitoringModule.incrementFailedHttpRequests();
+            pendingRequest.release();
+            return;
+        }
+
+        resending = pendingRequest;
+        ctx.channel().writeAndFlush(pendingRequest.request.retainedDuplicate());
+    }
+
+    private static boolean isRetriable(HttpResponseStatus status) {
+        return status.code() == HttpResponseStatus.TOO_MANY_REQUESTS.code()
+                || status.codeClass() == HttpStatusClass.SERVER_ERROR;
+    }
+
+    private static class PendingRequest {
+
+        private final FullHttpRequest request;
+        private int retriesLeft;
+
+        private PendingRequest(FullHttpRequest request, int retriesLeft) {
+            this.request = request;
+            this.retriesLeft = retriesLeft;
+        }
+
+        private void release() {
+            request.release();
+        }
     }
 }

--- a/core/src/test/java/pl/tkowalcz/tjahzi/http/PipelinedHttpRequestTimerTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/http/PipelinedHttpRequestTimerTest.java
@@ -34,7 +34,8 @@ class PipelinedHttpRequestTimerTest {
                 "localhost",
                 3100,
                 10_000,
-                42
+                42,
+                0
         );
 
         FullHttpRequest request = new DefaultFullHttpRequest(
@@ -85,7 +86,8 @@ class PipelinedHttpRequestTimerTest {
                 "localhost",
                 3100,
                 10_000,
-                42
+                42,
+                0
         );
 
         FullHttpRequest request = new DefaultFullHttpRequest(
@@ -142,7 +144,8 @@ class PipelinedHttpRequestTimerTest {
                 "localhost",
                 3100,
                 10_000,
-                42
+                42,
+                0
         );
 
         FullHttpRequest request = new DefaultFullHttpRequest(
@@ -203,7 +206,8 @@ class PipelinedHttpRequestTimerTest {
                 "localhost",
                 3100,
                 10_000,
-                42
+                42,
+                0
         );
 
         FullHttpRequest request = new DefaultFullHttpRequest(

--- a/core/src/test/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandlerTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandlerTest.java
@@ -1,0 +1,181 @@
+package pl.tkowalcz.tjahzi.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.ssl.SslContext;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.junit.jupiter.api.Test;
+import pl.tkowalcz.tjahzi.stats.StandardMonitoringModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class RequestAndResponseHandlerTest {
+
+    private static EmbeddedChannel createChannel(
+            StandardMonitoringModule monitoringModule,
+            int requestTimeoutMillis,
+            int maxRetries
+    ) {
+        HttpClientInitializer initializer = new HttpClientInitializer(
+                monitoringModule,
+                mock(SslContext.class),
+                "localhost",
+                3100,
+                requestTimeoutMillis,
+                42,
+                maxRetries
+        );
+
+        return new EmbeddedChannel(initializer);
+    }
+
+    private static FullHttpRequest createRequest() {
+        return new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.POST,
+                ClientConfigurationBuilder.DEFAULT_LOG_ENDPOINT,
+                Unpooled.wrappedBuffer("Boo hoo".getBytes())
+        );
+    }
+
+    private static DefaultFullHttpResponse createResponse(HttpResponseStatus status) {
+        DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                status
+        );
+
+        HttpUtil.setKeepAlive(response, true);
+        return response;
+    }
+
+    private static void drainOutbound(EmbeddedChannel channel) {
+        Object message;
+        while ((message = channel.readOutbound()) != null) {
+            if (message instanceof ByteBuf) {
+                ((ByteBuf) message).release();
+            }
+        }
+    }
+
+    @Test
+    void shouldRetryRequestAfterServerError() {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 10_000, 1);
+
+        // When
+        channel.writeOneOutbound(createRequest());
+        channel.flush();
+        drainOutbound(channel);
+
+        channel.writeOneInbound(createResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+        channel.flush();
+
+        // Then
+        Awaitility.await()
+                .atMost(Durations.FIVE_SECONDS)
+                .untilAsserted(() -> {
+                    channel.runScheduledPendingTasks();
+                    assertThat(monitoringModule.getSentHttpRequests()).isEqualTo(2);
+                });
+
+        assertThat(monitoringModule.getRetriedHttpRequests()).isEqualTo(1);
+        drainOutbound(channel);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void shouldGiveUpRetryingWhenRetriesAreExhausted() {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 10_000, 0);
+
+        FullHttpRequest request = createRequest();
+        ByteBuf content = request.content();
+
+        // When
+        channel.writeOneOutbound(request);
+        channel.flush();
+        drainOutbound(channel);
+
+        channel.writeOneInbound(createResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+        channel.flush();
+        channel.runScheduledPendingTasks();
+
+        // Then
+        assertThat(monitoringModule.getSentHttpRequests()).isEqualTo(1);
+        assertThat(monitoringModule.getRetriedHttpRequests()).isEqualTo(0);
+        assertThat(monitoringModule.getFailedHttpRequests()).isEqualTo(1);
+        assertThat(content.refCnt()).isEqualTo(0);
+
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void shouldNotRetryClientErrors() {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 10_000, 3);
+
+        FullHttpRequest request = createRequest();
+        ByteBuf content = request.content();
+
+        // When
+        channel.writeOneOutbound(request);
+        channel.flush();
+        drainOutbound(channel);
+
+        channel.writeOneInbound(createResponse(HttpResponseStatus.BAD_REQUEST));
+        channel.flush();
+        channel.runScheduledPendingTasks();
+
+        // Then
+        assertThat(monitoringModule.getSentHttpRequests()).isEqualTo(1);
+        assertThat(monitoringModule.getRetriedHttpRequests()).isEqualTo(0);
+        assertThat(content.refCnt()).isEqualTo(0);
+
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void shouldCloseChannelWhenResponseDoesNotArriveInTime() {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 50, 0);
+
+        // When
+        channel.writeOneOutbound(createRequest());
+        channel.flush();
+        drainOutbound(channel);
+
+        // Then
+        Awaitility.await()
+                .atMost(Durations.FIVE_SECONDS)
+                .untilAsserted(() -> {
+                    channel.runScheduledPendingTasks();
+                    assertThat(channel.isActive()).isFalse();
+                });
+
+        assertThat(monitoringModule.getFailedHttpRequests()).isEqualTo(1);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void shouldNotCloseIdleChannelWithNoRequestsInFlight() throws InterruptedException {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 50, 0);
+
+        // When
+        Thread.sleep(200);
+        channel.runScheduledPendingTasks();
+
+        // Then
+        assertThat(channel.isActive()).isTrue();
+        channel.finishAndReleaseAll();
+    }
+}


### PR DESCRIPTION
Fixes several defects in the HTTP/Netty layer found in a code audit of the released 0.9.42 code:

- **Request timeout never fired**: `IdleStateHandler` was built with the seconds-based constructor, so `requestTimeoutMillis=60000` meant a ~16.7 hour timeout — and no handler consumed the idle events anyway. Now configured in milliseconds; reader-idle with requests in flight records a pipeline error and closes the channel so the reconnect logic takes over. Idle connections with nothing in flight are left open.
- **429/5xx dropped the batch permanently**: only connection-level failures were retried. `RequestAndResponseHandler` (now per-channel instead of `@Sharable`) tracks in-flight requests in FIFO order — the same ordering assumption `PipelinedHttpRequestTimer` already relies on — and resends on 429/5xx with exponential backoff up to `maxRetries`. Requests still unacknowledged when a channel dies are released and counted as failed.
- **Reconnect backoff never reset**: after ~5 disconnects over a process lifetime (healthy keep-alive closes included) every reconnect waited the full 30s. The backoff now resets on successful connect.
- **Wedged connections**: `exceptionCaught` recorded the error but left the corrupt connection open; it now closes the channel.
- **Silent write failures**: `writeAndFlush` had no listener; failures are now counted and recorded.
- **`BlockingRetry` interrupt handling**: restored the interrupt flag and run the failure action (which releases the request buffer) instead of leaking it.
- **`DEFAULT_MAX_RETRIES` 0 → 3**, matching what the README has always documented.

Includes a new `RequestAndResponseHandlerTest` (retry, give-up, no-retry-on-4xx, read-timeout-close, idle-keep-open) — 33 tests green locally; full confirmation delegated to CI.
