### PR TITLE
Fix oversized log entry crash and dead-on-arrival monitoring error log

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/TjahziLogger.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/TjahziLogger.java
@@ -28,13 +28,20 @@ public class TjahziLogger {
             LabelSerializer structuredMetadata,
             ByteBuffer line
     ) {
-        int requiredSize = serializer.calculateRequiredSize(
-                serializedLabels,
-                structuredMetadata,
-                line
-        );
+        int claim;
+        try {
+            int requiredSize = serializer.calculateRequiredSize(
+                    serializedLabels,
+                    structuredMetadata,
+                    line
+            );
 
-        int claim = logBuffer.tryClaim(LOG_MESSAGE_TYPE_ID, requiredSize);
+            claim = logBuffer.tryClaim(LOG_MESSAGE_TYPE_ID, requiredSize);
+        } catch (Throwable t) {
+            monitoringModule.incrementDroppedPuts(t);
+            return this;
+        }
+
         if (claim > 0) {
             putMessageOnRing(
                     epochMillisecond,

--- a/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class StandardMonitoringModule implements MonitoringModule {
 
-    private static final int ERROR_LOG_CAPACITY = 1024;
+    private static final int ERROR_LOG_CAPACITY = 64 * 1024;
 
     private final AtomicLong droppedPuts = new AtomicLong();
     private final AtomicLong httpConnectAttempts = new AtomicLong();
@@ -26,17 +26,15 @@ public class StandardMonitoringModule implements MonitoringModule {
     private final DistinctErrorLog distinctErrorLog;
 
     public StandardMonitoringModule() {
-        StatsDumpingThread thread = new StatsDumpingThread(this);
-        if (thread.isEnabled()) {
-            thread.start();
-        }
-
         distinctErrorLog = new DistinctErrorLog(
                 new UnsafeBuffer(ByteBuffer.allocateDirect(ERROR_LOG_CAPACITY)),
                 new SystemEpochClock()
         );
 
-        distinctErrorLog.record(new NullPointerException());
+        StatsDumpingThread thread = new StatsDumpingThread(this);
+        if (thread.isEnabled()) {
+            thread.start();
+        }
     }
 
     @Override


### PR DESCRIPTION
Two core fixes from the 0.9.42 code audit:

- **Oversized entries threw into application code**: Agrona's `ManyToOneRingBuffer.tryClaim` throws `IllegalArgumentException` for messages larger than capacity/8 (4MB at the default 32MB buffer) rather than returning a negative claim, and `TjahziLogger.log` didn't guard the call — one large log line meant an exception on the caller's thread (relates to #106's report of surprising behavior around failed claims). Now caught and counted via `incrementDroppedPuts(t)`.
- **Monitoring error log was unusable**: `StandardMonitoringModule`'s constructor recorded a leftover debug `NullPointerException` into a 1KB `DistinctErrorLog`, occupying it so real errors couldn't record. Removed the debug line, grew the buffer to 64KB, and moved the stats-thread start to the end of the constructor to avoid publishing `this` before the error log is assigned.

Core test suite (803 tests) green locally; CI is the gate.
