### PR TITLE
Fix logback appender: nodep jar bundles logback, >10KB truncation, stop() NPE, label validation

### DIFF
--- a/logback-appender-nodep/pom.xml
+++ b/logback-appender-nodep/pom.xml
@@ -71,7 +71,7 @@
                         <configuration>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>ch.qos.logback.logback-classic</exclude>
+                                    <exclude>ch.qos.logback</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/logback-appender/src/main/java/ch/qos/logback/core/pattern/EfficientPatternLayout.java
+++ b/logback-appender/src/main/java/ch/qos/logback/core/pattern/EfficientPatternLayout.java
@@ -41,6 +41,29 @@ public class EfficientPatternLayout extends PatternLayoutBase<ILoggingEvent> {
         return encoder.getBuffer();
     }
 
+    /**
+     * Runs the converters for this event and prepares a thread local {@link Encoder} for
+     * fragmented encoding via {@link Encoder#encodeFragment()}. Use instead of
+     * {@link #doEfficientLayout(ILoggingEvent)} to handle messages larger than the
+     * encoder buffer without truncation.
+     */
+    public Encoder startEfficientLayout(ILoggingEvent event) {
+        StringBuilder strBuilder = StringBuilders.threadLocal();
+
+        if (isStarted()) {
+            Converter<ILoggingEvent> c = head;
+            while (c != null) {
+                c.write(strBuilder, event);
+                c = c.getNext();
+            }
+        }
+
+        Encoder encoder = Encoders.threadLocal();
+        encoder.startEncoding(strBuilder);
+
+        return encoder;
+    }
+
     @Override
     protected String getPresentationHeaderPrefix() {
         return PatternLayout.HEADER_PREFIX;

--- a/logback-appender/src/main/java/ch/qos/logback/core/pattern/Encoder.java
+++ b/logback-appender/src/main/java/ch/qos/logback/core/pattern/Encoder.java
@@ -20,18 +20,74 @@ public class Encoder {
     private final CharBuffer temporaryTextBuffer = CharBuffer.wrap(temporaryTextArray);
     private final CharsetEncoder charsetEncoder = StandardCharsets.UTF_8.newEncoder();
 
+    private StringBuilder input;
+    private int offset;
+    private int remainingInput;
+
+    /**
+     * Encodes as much of the input as fits into the internal buffer in one go. Input that does
+     * not fit is dropped. Use {@link #startEncoding(StringBuilder)} and {@link #encodeFragment()}
+     * to fragment messages larger than the buffer without losing data.
+     */
     public void encode(StringBuilder input) {
-        int offset = 0;
-        int sizeOfInput = input.length();
-        while (sizeOfInput > 0) {
-            int length = Math.min(sizeOfInput, temporaryTextArray.length);
-            sizeOfInput -= length;
+        startEncoding(input);
+        encodeFragment();
+    }
 
-            encodeRound(input, offset, length, sizeOfInput == 0);
-            offset += length;
+    public void startEncoding(StringBuilder input) {
+        this.input = input;
+        this.offset = 0;
+        this.remainingInput = input.length();
+
+        temporaryTextBuffer.clear().limit(0);
+    }
+
+    /**
+     * Encodes input into the internal buffer until either the input is exhausted or the buffer
+     * fills up. Flips the buffer so that it is ready for reading. Returns true if the buffer
+     * filled up and there is more input to encode - consume the buffer, call
+     * {@link #continueEncoding()} and invoke this method again to encode the remainder.
+     */
+    public boolean encodeFragment() {
+        while (true) {
+            if (!temporaryTextBuffer.hasRemaining() && remainingInput > 0) {
+                int length = Math.min(remainingInput, temporaryTextArray.length);
+                input.getChars(offset, offset + length, temporaryTextArray, 0);
+                temporaryTextBuffer.clear().limit(length);
+
+                offset += length;
+                remainingInput -= length;
+            }
+
+            boolean endOfInput = remainingInput == 0;
+            CoderResult coderResult = charsetEncoder.encode(
+                    temporaryTextBuffer,
+                    buffer,
+                    endOfInput
+            );
+
+            if (coderResult.isError()) {
+                throw new RuntimeException(coderResult.toString());
+            }
+
+            if (coderResult.isOverflow()) {
+                buffer.flip();
+                return true;
+            }
+
+            if (endOfInput) {
+                buffer.flip();
+                return false;
+            }
         }
+    }
 
-        buffer.flip();
+    /**
+     * Prepares the internal buffer for encoding the next fragment. Call after consuming
+     * a fragment produced by {@link #encodeFragment()}.
+     */
+    public void continueEncoding() {
+        buffer.clear();
     }
 
     public ByteBuffer getBuffer() {
@@ -41,20 +97,5 @@ public class Encoder {
     public void clear() {
         buffer.clear();
         charsetEncoder.reset();
-    }
-
-    private void encodeRound(StringBuilder input, int offset, int length, boolean endOfInput) {
-        input.getChars(offset, offset + length, temporaryTextArray, 0);
-        temporaryTextBuffer.clear().limit(length);
-
-        CoderResult coderResult = charsetEncoder.encode(
-                temporaryTextBuffer,
-                buffer,
-                endOfInput
-        );
-
-        if (coderResult.isError()) {
-            throw new RuntimeException(coderResult.toString());
-        }
     }
 }

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
@@ -3,6 +3,7 @@ package pl.tkowalcz.tjahzi.logback;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.EfficientPatternLayout;
+import ch.qos.logback.core.pattern.Encoder;
 import pl.tkowalcz.tjahzi.LabelSerializer;
 import pl.tkowalcz.tjahzi.LabelSerializerPair;
 import pl.tkowalcz.tjahzi.LabelSerializers;
@@ -69,7 +70,6 @@ public class LokiAppender extends LokiAppenderConfigurator {
         String logLevel = event.getLevel().toString();
         String loggerName = event.getLoggerName();
         String threadName = event.getThreadName();
-        ByteBuffer logLine = actualEncoder.apply(event);
         Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
 
         LabelSerializerPair labelSerializerPair = LabelSerializers.threadLocal();
@@ -82,13 +82,42 @@ public class LokiAppender extends LokiAppenderConfigurator {
         appendMdcLogLabels(labelSerializer, mdcPropertyMap);
         processStructuredMetadata(metadataSerializer, event);
 
-        logger.log(
-                event.getTimeStamp(),
-                event.getNanoseconds() % 1_000_000L,
-                labelSerializer,
-                metadataSerializer,
-                logLine
-        );
+        if (encoder == null) {
+            appendFragmented(event, labelSerializer, metadataSerializer);
+        } else {
+            logger.log(
+                    event.getTimeStamp(),
+                    event.getNanoseconds() % 1_000_000L,
+                    labelSerializer,
+                    metadataSerializer,
+                    actualEncoder.apply(event)
+            );
+        }
+    }
+
+    private void appendFragmented(
+            ILoggingEvent event,
+            LabelSerializer labelSerializer,
+            LabelSerializer metadataSerializer
+    ) {
+        Encoder lineEncoder = efficientLayout.startEfficientLayout(event);
+
+        boolean hasMoreFragments;
+        do {
+            hasMoreFragments = lineEncoder.encodeFragment();
+
+            logger.log(
+                    event.getTimeStamp(),
+                    event.getNanoseconds() % 1_000_000L,
+                    labelSerializer,
+                    metadataSerializer,
+                    lineEncoder.getBuffer()
+            );
+
+            if (hasMoreFragments) {
+                lineEncoder.continueEncoding();
+            }
+        } while (hasMoreFragments);
     }
 
     private void processStructuredMetadata(LabelSerializer labelSerializer, ILoggingEvent event) {
@@ -161,10 +190,12 @@ public class LokiAppender extends LokiAppenderConfigurator {
             monitoringModuleWrapper.onClose();
         }
 
-        loggingSystem.close(
-                (int) TimeUnit.SECONDS.toMillis(getShutdownTimeoutSeconds()),
-                thread -> addError("Loki appender was unable to stop thread on shutdown: " + thread)
-        );
+        if (loggingSystem != null) {
+            loggingSystem.close(
+                    (int) TimeUnit.SECONDS.toMillis(getShutdownTimeoutSeconds()),
+                    thread -> addError("Loki appender was unable to stop thread on shutdown: " + thread)
+            );
+        }
 
         super.stop();
     }

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
@@ -10,6 +10,7 @@ import pl.tkowalcz.tjahzi.stats.LoggingMonitoringModule;
 import pl.tkowalcz.tjahzi.stats.MutableMonitoringModuleWrapper;
 import pl.tkowalcz.tjahzi.stats.StandardMonitoringModule;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -52,8 +53,24 @@ public class LokiAppenderFactory {
         );
 
         structuredMetadata = structuredMetadataFactory.convertLabelsDroppingInvalid();
-        mdcLogLabels = configurator.getMdcLogLabels();
+        mdcLogLabels = validateMdcLogLabels(configurator);
         monitoringModuleWrapper = new MutableMonitoringModuleWrapper();
+    }
+
+    private static List<String> validateMdcLogLabels(LokiAppenderConfigurator configurator) {
+        List<String> result = new ArrayList<>();
+
+        for (String mdcLogLabel : configurator.getMdcLogLabels()) {
+            if (Label.hasValidName(mdcLogLabel)) {
+                result.add(mdcLogLabel);
+            } else {
+                configurator.addError(
+                        "Ignoring mdcLogLabel '" + mdcLogLabel + "' - it is not a valid Loki label name"
+                );
+            }
+        }
+
+        return result;
     }
 
     public LoggingSystem createAppender() {

--- a/logback-appender/src/test/java/ch/qos/logback/core/pattern/EncoderTest.java
+++ b/logback-appender/src/test/java/ch/qos/logback/core/pattern/EncoderTest.java
@@ -99,4 +99,69 @@ class EncoderTest {
         // Then
         assertThat(encoder.getBuffer()).isEqualTo(expected);
     }
+
+    @Test
+    void shouldFragmentLongerMessagesWithoutLosingData() {
+        // Given
+        Encoder encoder = new Encoder();
+
+        String toEncode = RandomStringUtils.randomAlphanumeric(40 * 1024 + 41);
+        ByteBuffer expected = wrap(toEncode.getBytes(StandardCharsets.UTF_8));
+
+        // When
+        encoder.startEncoding(new StringBuilder(toEncode));
+
+        ByteBuffer actual = ByteBuffer.allocate(64 * 1024);
+        int fragments = 0;
+
+        boolean hasMoreFragments;
+        do {
+            hasMoreFragments = encoder.encodeFragment();
+            fragments++;
+
+            actual.put(encoder.getBuffer());
+            if (hasMoreFragments) {
+                encoder.continueEncoding();
+            }
+        } while (hasMoreFragments);
+
+        actual.flip();
+
+        // Then
+        assertThat(fragments).isEqualTo(5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldFragmentMultiByteCharactersWithoutCorruption() {
+        // Given
+        Encoder encoder = new Encoder();
+
+        StringBuilder toEncode = new StringBuilder();
+        for (int i = 0; i < 11 * 1024; i++) {
+            toEncode.append('ż');
+        }
+
+        ByteBuffer expected = wrap(toEncode.toString().getBytes(StandardCharsets.UTF_8));
+
+        // When
+        encoder.startEncoding(toEncode);
+
+        ByteBuffer actual = ByteBuffer.allocate(64 * 1024);
+
+        boolean hasMoreFragments;
+        do {
+            hasMoreFragments = encoder.encodeFragment();
+
+            actual.put(encoder.getBuffer());
+            if (hasMoreFragments) {
+                encoder.continueEncoding();
+            }
+        } while (hasMoreFragments);
+
+        actual.flip();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
Four logback fixes from the 0.9.42 code audit:

- **Published nodep jar bundles logback** (worst finding of the audit — verified against the actual Maven Central 0.9.42 artifact, which contains 200+ unrelocated `ch.qos.logback` classes): the shade exclude said `ch.qos.logback.logback-classic` — dot instead of the `groupId:artifactId` colon — and never covered logback-core. Now excludes the whole `ch.qos.logback` groupId, same pattern as the (correct) log4j2 nodep pom. Verified: the rebuilt jar contains zero logback library classes; only tjahzi's own four layout classes remain in that package, with shaded netty intact.
- **Lines over 10KB were silently truncated** despite the encoder's javadoc promising fragmentation: `CoderResult.OVERFLOW` was ignored. The `Encoder` now exposes `startEncoding`/`encodeFragment`/`continueEncoding` and the appender ships oversized lines as multiple consecutive entries (matching log4j2 appender behavior), preserving the zero-allocation happy path. Multi-byte UTF-8 characters split across fragment boundaries are handled by the CharsetEncoder's internal state.
- **`stop()` NPEd after failed `start()`** (e.g. no encoder configured), breaking `LoggerContext.stop()`/reconfiguration; now a safe no-op.
- **`mdcLogLabel` names were never validated**: an invalid Loki label name (e.g. `user-id`) caused whole push batches to be rejected with HTTP 400 whenever the MDC key was present. Invalid names are now dropped at startup with an error naming the label.

New fragmentation tests (including a multi-byte boundary case) — 49 targeted tests green locally; CI is the gate.