### PR TITLE
Fix reload4j appender: missing stack traces, shutdown timeout, NPE storm, label validation

### DIFF
--- a/reload4j-appender/README.md
+++ b/reload4j-appender/README.md
@@ -108,7 +108,7 @@ As per the `log4j1.x` convention configuration parameters are set using
 ```
 
 The appender implements `UnrecognizedElementHandler` interface and
-handles additional nested tags: `label`, `header`, and `mdcLabel`:
+handles additional nested tags: `label`, `header`, and `mdcLogLabel`:
 
 ```xml
 

--- a/reload4j-appender/src/main/java/pl/tkowalcz/tjahzi/reload4j/LokiAppender.java
+++ b/reload4j-appender/src/main/java/pl/tkowalcz/tjahzi/reload4j/LokiAppender.java
@@ -1,15 +1,19 @@
 package pl.tkowalcz.tjahzi.reload4j;
 
+import org.apache.log4j.Layout;
+import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.spi.LoggingEvent;
 import pl.tkowalcz.tjahzi.LabelSerializer;
 import pl.tkowalcz.tjahzi.LabelSerializers;
 import pl.tkowalcz.tjahzi.LoggingSystem;
 import pl.tkowalcz.tjahzi.TjahziLogger;
+import pl.tkowalcz.tjahzi.github.GitHubDocs;
 import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 import pl.tkowalcz.tjahzi.stats.MutableMonitoringModuleWrapper;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +42,11 @@ public class LokiAppender extends LokiAppenderConfigurator {
 
     @Override
     protected void append(LoggingEvent event) {
-        String formattedMessage = layout.format(event);
+        if (!checkEntryConditions()) {
+            return;
+        }
+
+        String formattedMessage = formatLogLine(event);
         ByteBuffer logLine = ByteBuffer.wrap(formattedMessage.getBytes(StandardCharsets.UTF_8));
 
         String logLevel = event.getLevel().toString();
@@ -61,6 +69,41 @@ public class LokiAppender extends LokiAppenderConfigurator {
                 new LabelSerializer(),
                 logLine
         );
+    }
+
+    String formatLogLine(LoggingEvent event) {
+        String formattedMessage = layout.format(event);
+
+        if (layout.ignoresThrowable()) {
+            String[] throwableStrRep = event.getThrowableStrRep();
+
+            if (throwableStrRep != null) {
+                StringBuilder logLineBuilder = new StringBuilder(formattedMessage);
+
+                for (int i = 0; i < throwableStrRep.length; i++) {
+                    logLineBuilder.append(throwableStrRep[i]);
+                    logLineBuilder.append(Layout.LINE_SEP);
+                }
+
+                return logLineBuilder.toString();
+            }
+        }
+
+        return formattedMessage;
+    }
+
+    private boolean checkEntryConditions() {
+        if (closed) {
+            LogLog.warn("Not allowed to write to a closed appender.");
+            return false;
+        }
+
+        if (logger == null || loggingSystem == null) {
+            errorHandler.error("Appender [" + name + "] is not started or failed to initialize - dropping log event.");
+            return false;
+        }
+
+        return true;
     }
 
     private void appendLogLabel(LabelSerializer labelSerializer, String logLevel) {
@@ -106,11 +149,31 @@ public class LokiAppender extends LokiAppenderConfigurator {
         logLevelLabel = lokiAppenderFactory.getLogLevelLabel();
         loggerNameLabel = lokiAppenderFactory.getLoggerNameLabel();
         threadNameLabel = lokiAppenderFactory.getThreadNameLabel();
-        mdcLogLabels = lokiAppenderFactory.getMdcLogLabels();
+        mdcLogLabels = dropInvalidMdcLogLabels(lokiAppenderFactory.getMdcLogLabels());
         monitoringModuleWrapper = lokiAppenderFactory.getMonitoringModuleWrapper();
 
         logger = loggingSystem.createLogger();
         loggingSystem.start();
+    }
+
+    private List<String> dropInvalidMdcLogLabels(List<String> mdcLogLabels) {
+        List<String> result = new ArrayList<>(mdcLogLabels.size());
+
+        for (String mdcLogLabel : mdcLogLabels) {
+            if (Label.hasValidName(mdcLogLabel)) {
+                result.add(mdcLogLabel);
+            } else {
+                LogLog.error(
+                        String.format(
+                                "Ignoring MDC log label '%s' - contains invalid characters. %s\n",
+                                mdcLogLabel,
+                                GitHubDocs.LABEL_NAMING.getLogMessage()
+                        )
+                );
+            }
+        }
+
+        return result;
     }
 
     @Override
@@ -125,7 +188,7 @@ public class LokiAppender extends LokiAppenderConfigurator {
 
         if (loggingSystem != null) {
             loggingSystem.close(
-                    (int) TimeUnit.SECONDS.toMillis(10), // Default 10 second timeout
+                    (int) TimeUnit.SECONDS.toMillis(getShutdownTimeoutSeconds()),
                     thread -> errorHandler.error("Loki appender was unable to stop thread on shutdown: " + thread)
             );
         }

--- a/reload4j-appender/src/test/java/pl/tkowalcz/tjahzi/reload4j/LokiAppenderThrowableTest.java
+++ b/reload4j-appender/src/test/java/pl/tkowalcz/tjahzi/reload4j/LokiAppenderThrowableTest.java
@@ -1,0 +1,56 @@
+package pl.tkowalcz.tjahzi.reload4j;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LokiAppenderThrowableTest {
+
+    @Test
+    void shouldAppendStackTraceWhenLayoutIgnoresThrowable() {
+        // Given
+        LokiAppender appender = new LokiAppender();
+        appender.setLayout(new PatternLayout("%m"));
+
+        LoggingEvent event = new LoggingEvent(
+                Logger.class.getName(),
+                Logger.getLogger(LokiAppenderThrowableTest.class),
+                Level.ERROR,
+                "boom",
+                new RuntimeException("Kaboom!")
+        );
+
+        // When
+        String logLine = appender.formatLogLine(event);
+
+        // Then
+        assertThat(logLine).startsWith("boom");
+        assertThat(logLine).contains("java.lang.RuntimeException: Kaboom!");
+        assertThat(logLine).contains("at " + LokiAppenderThrowableTest.class.getName());
+    }
+
+    @Test
+    void shouldNotAlterLogLineWhenThereIsNoThrowable() {
+        // Given
+        LokiAppender appender = new LokiAppender();
+        appender.setLayout(new PatternLayout("%m"));
+
+        LoggingEvent event = new LoggingEvent(
+                Logger.class.getName(),
+                Logger.getLogger(LokiAppenderThrowableTest.class),
+                Level.INFO,
+                "Hello World",
+                null
+        );
+
+        // When
+        String logLine = appender.formatLogLine(event);
+
+        // Then
+        assertThat(logLine).isEqualTo("Hello World");
+    }
+}


### PR DESCRIPTION
Four reload4j fixes plus a docs correction from the 0.9.42 code audit:

- **Stack traces never reached Loki**: `append()` ignored the log4j 1.x contract that the appender must emit `event.getThrowableStrRep()` when `layout.ignoresThrowable()` is true (which `PatternLayout` is) — `log.error("boom", e)` shipped without the exception. Now appended line-by-line after the formatted message.
- **`close()` hardcoded a 10s flush timeout**, ignoring the documented `shutdownTimeoutSeconds` setting (the logback appender honors it); tail logs were lost on slow shutdowns.
- **Missing-layout misconfiguration caused an NPE on every log call** on the application thread; `append()` now checks entry conditions (mirroring `WriterAppender.checkEntryConditions()`) and reports through the error handler instead.
- **`mdcLogLabel` names are now validated** at `activateOptions()`; invalid Loki label names are dropped with an error instead of poisoning entire push batches with HTTP 400.
- README: the nested tag is `mdcLogLabel`, not `mdcLabel`.

Includes a new `LokiAppenderThrowableTest` — green locally; CI is the gate.
