### PR TITLE
[0.9.x] Oversized log entry crash and monitoring error log

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/TjahziLogger.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/TjahziLogger.java
@@ -28,13 +28,20 @@ public class TjahziLogger {
             LabelSerializer structuredMetadata,
             ByteBuffer line
     ) {
-        int requiredSize = serializer.calculateRequiredSize(
-                serializedLabels,
-                structuredMetadata,
-                line
-        );
+        int claim;
+        try {
+            int requiredSize = serializer.calculateRequiredSize(
+                    serializedLabels,
+                    structuredMetadata,
+                    line
+            );
 
-        int claim = logBuffer.tryClaim(LOG_MESSAGE_TYPE_ID, requiredSize);
+            claim = logBuffer.tryClaim(LOG_MESSAGE_TYPE_ID, requiredSize);
+        } catch (Throwable t) {
+            monitoringModule.incrementDroppedPuts(t);
+            return this;
+        }
+
         if (claim > 0) {
             putMessageOnRing(
                     epochMillisecond,

--- a/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class StandardMonitoringModule implements MonitoringModule {
 
-    private static final int ERROR_LOG_CAPACITY = 1024;
+    private static final int ERROR_LOG_CAPACITY = 64 * 1024;
 
     private final AtomicLong droppedPuts = new AtomicLong();
     private final AtomicLong httpConnectAttempts = new AtomicLong();
@@ -26,17 +26,15 @@ public class StandardMonitoringModule implements MonitoringModule {
     private final DistinctErrorLog distinctErrorLog;
 
     public StandardMonitoringModule() {
-        StatsDumpingThread thread = new StatsDumpingThread(this);
-        if (thread.isEnabled()) {
-            thread.start();
-        }
-
         distinctErrorLog = new DistinctErrorLog(
                 new UnsafeBuffer(ByteBuffer.allocateDirect(ERROR_LOG_CAPACITY)),
                 new SystemEpochClock()
         );
 
-        distinctErrorLog.record(new NullPointerException());
+        StatsDumpingThread thread = new StatsDumpingThread(this);
+        if (thread.isEnabled()) {
+            thread.start();
+        }
     }
 
     @Override


### PR DESCRIPTION
Backport of #169 to the 0.9.x release train (clean cherry-pick). See #169 for full description and verification. Intended to ship in 0.9.43.
