### PR TITLE
[0.9.x] log4j2 appender fixes

### DIFF
--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/LokiAppenderBuilder.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/LokiAppenderBuilder.java
@@ -117,6 +117,18 @@ public class LokiAppenderBuilder<B extends LokiAppenderBuilder<B>> extends Abstr
 
     @Override
     public LokiAppender build() {
+        if (headers == null) {
+            headers = new Header[0];
+        }
+
+        if (labels == null) {
+            labels = new Label[0];
+        }
+
+        if (metadata == null) {
+            metadata = new StructuredMetadata[0];
+        }
+
         ClientConfiguration configurationBuilder = ClientConfiguration.builder()
                 .withUrl(url)
                 .withLogEndpoint(logEndpoint)
@@ -172,7 +184,7 @@ public class LokiAppenderBuilder<B extends LokiAppenderBuilder<B>> extends Abstr
 
         LabelFactory metadataFactory = new LabelFactory(
                 getConfiguration(),
-                logLevelLabel,
+                null,
                 metadata
         );
 

--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/TjahziByteBufferDestination.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/TjahziByteBufferDestination.java
@@ -19,7 +19,7 @@ public class TjahziByteBufferDestination implements ByteBufferDestination {
     }
 
     public void drainRemaining() {
-        if (buffer.hasRemaining()) {
+        if (buffer.position() > 0) {
             drain(buffer);
         }
     }

--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelBase.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelBase.java
@@ -46,6 +46,6 @@ public abstract class LabelBase {
     }
 
     public static boolean hasValidName(String label) {
-        return LABEL_NAME_PATTER.matcher(label).matches();
+        return label != null && LABEL_NAME_PATTER.matcher(label).matches();
     }
 }

--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelFactory.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelFactory.java
@@ -35,9 +35,11 @@ public class LabelFactory {
     }
 
     public LabelsDescriptor convertLabelsDroppingInvalid() {
-        detectAndLogDuplicateLabels();
+        LabelBase[] validLabels = dropAndLogLabelsWithInvalidNames();
 
-        Map<String, LabelPrinter> allLabels = convertAndLogViolations();
+        detectAndLogDuplicateLabels(validLabels);
+
+        Map<String, LabelPrinter> allLabels = convert(validLabels);
 
         Map<String, LabelPrinter> dynamicLabels = new HashMap<>();
         allLabels
@@ -66,8 +68,27 @@ public class LabelFactory {
         );
     }
 
-    private void detectAndLogDuplicateLabels() {
-        List<String> duplicatedLabels = stream(labels)
+    private LabelBase[] dropAndLogLabelsWithInvalidNames() {
+        return stream(labels)
+                .flatMap(label -> {
+                            if (label.hasValidName()) {
+                                return Stream.of(label);
+                            }
+
+                            LOGGER.error(
+                                    "Ignoring label '{}' - contains invalid characters. {}",
+                                    label.getName(),
+                                    GitHubDocs.LABEL_NAMING.getLogMessage()
+                            );
+
+                            return Stream.of();
+                        }
+                )
+                .toArray(LabelBase[]::new);
+    }
+
+    private void detectAndLogDuplicateLabels(LabelBase[] validLabels) {
+        List<String> duplicatedLabels = stream(validLabels)
                 .collect(Collectors.groupingBy(LabelBase::getName, counting()))
                 .entrySet()
                 .stream()
@@ -84,22 +105,8 @@ public class LabelFactory {
         }
     }
 
-    private Map<String, LabelPrinter> convertAndLogViolations() {
-        return stream(labels)
-                .flatMap(label -> {
-                            if (label.hasValidName()) {
-                                return Stream.of(label);
-                            }
-
-                            LOGGER.error(
-                                    "Ignoring label '{}' - contains invalid characters. {}",
-                                    label.getName(),
-                                    GitHubDocs.LABEL_NAMING.getLogMessage()
-                            );
-
-                            return Stream.of();
-                        }
-                )
+    private Map<String, LabelPrinter> convert(LabelBase[] validLabels) {
+        return stream(validLabels)
                 .collect(toMap(
                         LabelBase::getName,
                         this::toLabelOrLog4jPattern,

--- a/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/Log4jAdapterLabelPrinter.java
+++ b/log4j2-appender/src/main/java/pl/tkowalcz/tjahzi/log4j2/labels/Log4jAdapterLabelPrinter.java
@@ -40,7 +40,9 @@ public class Log4jAdapterLabelPrinter implements LabelPrinter {
                 }
             }
 
-            return !converter.isVariable();
+            if (converter.isVariable()) {
+                return false;
+            }
         }
 
         return true;

--- a/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/TjahziByteBufferDestinationTest.java
+++ b/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/TjahziByteBufferDestinationTest.java
@@ -1,0 +1,86 @@
+package pl.tkowalcz.tjahzi.log4j2;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.MutableLogEvent;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TjahziByteBufferDestinationTest {
+
+    @Test
+    void shouldDrainBufferFilledExactlyToCapacity() {
+        // Given
+        int capacity = 4;
+        TjahziByteBufferDestination destination = new TjahziByteBufferDestination(capacity);
+
+        List<byte[]> drainedChunks = new ArrayList<>();
+        BiConsumer<LogEvent, ByteBuffer> drain = (logEvent, byteBuffer) -> {
+            byte[] chunk = new byte[byteBuffer.remaining()];
+            byteBuffer.get(chunk);
+            drainedChunks.add(chunk);
+        };
+
+        MutableLogEvent logEvent = new MutableLogEvent();
+        destination.initialize(drain, logEvent);
+
+        destination.writeBytes("blah".getBytes(), 0, capacity);
+
+        // When
+        destination.drainRemaining();
+
+        // Then
+        assertThat(drainedChunks).containsExactly("blah".getBytes());
+    }
+
+    @Test
+    void shouldNotDrainEmptyBuffer() {
+        // Given
+        TjahziByteBufferDestination destination = new TjahziByteBufferDestination(4);
+
+        List<byte[]> drainedChunks = new ArrayList<>();
+        BiConsumer<LogEvent, ByteBuffer> drain = (logEvent, byteBuffer) -> {
+            byte[] chunk = new byte[byteBuffer.remaining()];
+            byteBuffer.get(chunk);
+            drainedChunks.add(chunk);
+        };
+
+        MutableLogEvent logEvent = new MutableLogEvent();
+        destination.initialize(drain, logEvent);
+
+        // When
+        destination.drainRemaining();
+
+        // Then
+        assertThat(drainedChunks).isEmpty();
+    }
+
+    @Test
+    void shouldDrainPartiallyFilledBuffer() {
+        // Given
+        TjahziByteBufferDestination destination = new TjahziByteBufferDestination(16);
+
+        List<byte[]> drainedChunks = new ArrayList<>();
+        BiConsumer<LogEvent, ByteBuffer> drain = (logEvent, byteBuffer) -> {
+            byte[] chunk = new byte[byteBuffer.remaining()];
+            byteBuffer.get(chunk);
+            drainedChunks.add(chunk);
+        };
+
+        MutableLogEvent logEvent = new MutableLogEvent();
+        destination.initialize(drain, logEvent);
+
+        destination.writeBytes("blah".getBytes(), 0, 4);
+
+        // When
+        destination.drainRemaining();
+
+        // Then
+        assertThat(drainedChunks).containsExactly("blah".getBytes());
+    }
+}

--- a/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelFactoryTest.java
+++ b/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/labels/LabelFactoryTest.java
@@ -103,6 +103,28 @@ class LabelFactoryTest {
     }
 
     @Test
+    void shouldSkipLabelsWithNullName() {
+        // Given
+        Label thisShouldStay = Label.createLabel("ip", "10.0.2.34", null);
+        Label nullNameShouldBeDropped = Label.createLabel(null, "hostname", null);
+
+        LabelFactory labelFactory = new LabelFactory(
+                new NullConfiguration(),
+                "log_level",
+                thisShouldStay,
+                nullNameShouldBeDropped
+        );
+
+        // When
+        LabelsDescriptor actual = labelFactory.convertLabelsDroppingInvalid();
+
+        // Then
+        assertThat(actual.getStaticLabels()).containsOnly(
+                asEntry(thisShouldStay)
+        );
+    }
+
+    @Test
     void shouldAcceptNullLogLevel() {
         // Given
         Label label1 = Label.createLabel("ip", "10.0.2.34", null);

--- a/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/labels/Log4jAdapterLabelPrinterTest.java
+++ b/log4j2-appender/src/test/java/pl/tkowalcz/tjahzi/log4j2/labels/Log4jAdapterLabelPrinterTest.java
@@ -98,7 +98,8 @@ class Log4jAdapterLabelPrinterTest {
                 Arguments.of("Empty", "", true),
                 Arguments.of("Literal value", "literal value", true),
                 Arguments.of("Literal value with variable", "Literal & variable: ${server}", false),
-                Arguments.of("Contains pattern", "With pattern %c{1}", true) // Since 2.15.0 no interpolation possible
+                Arguments.of("Contains pattern", "With pattern %c{1}", false),
+                Arguments.of("Literal followed by MDC pattern", "myapp-%X{region}", false)
         );
     }
 


### PR DESCRIPTION
Backport of #170 to the 0.9.x release train (clean cherry-pick). See #170 for full description and verification. Intended to ship in 0.9.43.
