### PR TITLE
Fix flaky integration tests: properties config leaked root-logger Loki appender

### DIFF
--- a/log4j2-appender/src/test/resources/appender-test-with-log-label-set.properties
+++ b/log4j2-appender/src/test/resources/appender-test-with-log-label-set.properties
@@ -1,11 +1,12 @@
 packages="pl.tkowalcz.tjahzi.log4j2"
 
-# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
-monitorInterval=30
+rootLogger.level = OFF
 
-rootLogger.level = INFO
-rootLogger.appenderRefs = loki
-rootLogger.appenderRef.loki.ref = loki-appender
+loggers = tjahzi
+
+logger.tjahzi.name = pl.tkowalcz
+logger.tjahzi.level = ALL
+logger.tjahzi.appenderRef.loki.ref = loki-appender
 
 appender.loki.name = loki-appender
 appender.loki.type = Loki


### PR DESCRIPTION
Root cause of the intermittent `LogLineFragmentationTest` failures seen in CI builds 753/756 (and any other test asserting on the `{server="127.0.0.1"}` query).

`appender-test-with-log-label-set.properties` was the only test config attaching the Loki appender to the **root logger at INFO** (all XML configs scope to `pl.tkowalcz` with root OFF), plus `monitorInterval=30`. Since surefire runs all test classes in one reused JVM, after `LokiPropertiesFileTest` finished, third-party INFO logs (testcontainers, awaitility) kept flowing into a Loki appender labeled `{server=127.0.0.1, source=log4j, log_level}`, and the 30s config reload could re-resolve `${sys:loki.port}` to a later test's fresh container — injecting a second stream into that test's assertions. Failure depends on test order (filesystem-dependent) and timing, hence the flakiness.

Scoped the config like every other test config and dropped the reload interval. `LokiPropertiesFileTest` still verifies properties-format configuration and passes locally in 23s.
