### PR TITLE
[0.9.x] Fix flaky integration tests: properties config leaked root-logger Loki appender

### DIFF
--- a/log4j2-appender/src/test/resources/appender-test-with-log-label-set.properties
+++ b/log4j2-appender/src/test/resources/appender-test-with-log-label-set.properties
@@ -1,11 +1,12 @@
 packages="pl.tkowalcz.tjahzi.log4j2"
 
-# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
-monitorInterval=30
+rootLogger.level = OFF
 
-rootLogger.level = INFO
-rootLogger.appenderRefs = loki
-rootLogger.appenderRef.loki.ref = loki-appender
+loggers = tjahzi
+
+logger.tjahzi.name = pl.tkowalcz
+logger.tjahzi.level = ALL
+logger.tjahzi.appenderRef.loki.ref = loki-appender
 
 appender.loki.name = loki-appender
 appender.loki.type = Loki


### PR DESCRIPTION
Backport of the test-isolation deflake (clean cherry-pick) — root cause of the CI failures on builds 753/756. See the master PR for full analysis.
