### PR TITLE
Fix data loss on shutdown: await delivery of the final batch

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/LogShipperAgent.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/LogShipperAgent.java
@@ -3,6 +3,7 @@ package pl.tkowalcz.tjahzi;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import pl.tkowalcz.tjahzi.http.NettyHttpClient;
+import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 
 import java.io.IOException;
 
@@ -17,13 +18,15 @@ public class LogShipperAgent implements Agent {
 
     private final LogBufferMessageHandler messageHandler;
     private final TimeCappedBatchingStrategy batchStrategy;
+    private final MonitoringModule monitoringModule;
 
     public LogShipperAgent(
             TimeCappedBatchingStrategy batchStrategy,
             ManyToOneRingBuffer logBuffer,
             OutputBuffer outputBuffer,
             NettyHttpClient httpClient,
-            LogBufferMessageHandler messageHandler) {
+            LogBufferMessageHandler messageHandler,
+            MonitoringModule monitoringModule) {
         this.batchStrategy = batchStrategy;
 
         this.logBuffer = logBuffer;
@@ -31,6 +34,7 @@ public class LogShipperAgent implements Agent {
         this.messageHandler = messageHandler;
 
         this.outputBuffer = outputBuffer;
+        this.monitoringModule = monitoringModule;
     }
 
     private int doWork(boolean isTerminating) throws IOException {
@@ -66,6 +70,13 @@ public class LogShipperAgent implements Agent {
             }
 
         } while (workDone != 0 && batchStrategy.shouldContinueShutdown());
+
+        // Whatever is still in the buffer will never be delivered - make the
+        // loss visible in monitoring instead of dropping it silently.
+        logBuffer.read(
+                (msgTypeId, buffer, index, length) -> monitoringModule.incrementDroppedPuts(),
+                Integer.MAX_VALUE
+        );
     }
 
     @Override

--- a/core/src/main/java/pl/tkowalcz/tjahzi/LogShipperAgent.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/LogShipperAgent.java
@@ -36,7 +36,8 @@ public class LogShipperAgent implements Agent {
     private int doWork(boolean isTerminating) throws IOException {
         int workDone = logBuffer.read(messageHandler, MAX_MESSAGES_TO_RETRIEVE);
 
-        if (isTerminating || batchStrategy.shouldProceed()) {
+        if (outputBuffer.getBytesPending() > 0
+                && (isTerminating || batchStrategy.shouldProceed())) {
             try {
                 httpClient.log(outputBuffer);
             } finally {

--- a/core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/LoggingSystem.java
@@ -2,6 +2,7 @@ package pl.tkowalcz.tjahzi;
 
 import org.agrona.concurrent.AgentRunner;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import pl.tkowalcz.tjahzi.http.NettyHttpClient;
 import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 
 import java.io.Closeable;
@@ -50,14 +51,27 @@ public class LoggingSystem {
     public void close(
             int retryCloseTimeoutMs,
             Consumer<Thread> closeFailAction) {
+        long deadline = System.currentTimeMillis() + retryCloseTimeoutMs;
+
         runner.close(
                 retryCloseTimeoutMs,
                 closeFailAction
         );
 
+        // Give the http client at least a second to deliver the final batch even
+        // if draining the log buffer consumed the whole shutdown budget.
+        long remainingBudgetMillis = Math.max(
+                1_000,
+                deadline - System.currentTimeMillis()
+        );
+
         for (Closeable resource : resourcesToCleanup) {
             try {
-                resource.close();
+                if (resource instanceof NettyHttpClient) {
+                    ((NettyHttpClient) resource).close(remainingBudgetMillis);
+                } else {
+                    resource.close();
+                }
             } catch (Exception ignore) {
             }
         }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/TjahziInitializer.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/TjahziInitializer.java
@@ -51,7 +51,8 @@ public class TjahziInitializer {
                         logBuffer,
                         staticLabels,
                         outputBuffer
-                )
+                ),
+                monitoringModule
         );
 
         AgentRunner runner = new AgentRunner(

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/HttpConnection.java
@@ -7,10 +7,15 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import pl.tkowalcz.tjahzi.stats.MonitoringModule;
 
+import io.netty.channel.Channel;
+
 import java.io.Closeable;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 public class HttpConnection implements Closeable {
+
+    private static final long DEFAULT_CLOSE_TIMEOUT_MILLIS = 10_000;
 
     private final ClientConfiguration clientConfiguration;
     private final MonitoringModule monitoringModule;
@@ -96,6 +101,52 @@ public class HttpConnection implements Closeable {
 
     @Override
     public void close() {
-        group.shutdownGracefully();
+        close(DEFAULT_CLOSE_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Closes the connection waiting for outstanding requests to be acknowledged by Loki
+     * and for the event loop to flush and terminate, so that the last batch is not lost
+     * when the JVM exits right after this method returns.
+     */
+    public void close(long timeoutMillis) {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+
+        awaitOutstandingRequests(deadline);
+
+        group.shutdownGracefully(0, timeoutMillis, TimeUnit.MILLISECONDS);
+        group.terminationFuture()
+                .awaitUninterruptibly(Math.max(1, deadline - System.currentTimeMillis()));
+    }
+
+    private void awaitOutstandingRequests(long deadline) {
+        ChannelFuture stableReference = this.lokiConnection;
+        if (stableReference == null || !stableReference.isDone() || !stableReference.isSuccess()) {
+            return;
+        }
+
+        Channel channel = stableReference.channel();
+        if (!channel.isActive()) {
+            return;
+        }
+
+        try {
+            // A noop task behind any queued writes - once it completes all
+            // preceding writeAndFlush calls have registered their requests.
+            channel.eventLoop()
+                    .submit(() -> {
+                    })
+                    .await(Math.max(1, deadline - System.currentTimeMillis()));
+
+            RequestAndResponseHandler handler = channel.pipeline().get(RequestAndResponseHandler.class);
+            while (handler != null
+                    && handler.outstandingRequests() > 0
+                    && channel.isActive()
+                    && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/NettyHttpClient.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/NettyHttpClient.java
@@ -71,6 +71,10 @@ public class NettyHttpClient implements Closeable {
         lokiConnection.close();
     }
 
+    public void close(long timeoutMillis) {
+        lokiConnection.close(timeoutMillis);
+    }
+
     public void log(OutputBuffer outputBuffer) throws IOException {
         ByteBuf dataBuffer = outputBuffer.close();
         ByteBuf compressedBuffer = PooledByteBufAllocator.DEFAULT.buffer();

--- a/core/src/main/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandler.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandler.java
@@ -28,6 +28,9 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
 
     private PendingRequest resending;
 
+    // Written only from the event loop, read from the thread closing the connection.
+    private volatile int outstandingRequests;
+
     RequestAndResponseHandler(MonitoringModule monitoringModule, int maxRetries) {
         this.monitoringModule = monitoringModule;
         this.maxRetries = maxRetries;
@@ -49,6 +52,8 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
                                 maxRetries
                         )
                 );
+
+                outstandingRequests++;
             }
         }
 
@@ -72,7 +77,7 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
             retryBackoff.reset();
 
             if (pendingRequest != null) {
-                pendingRequest.release();
+                completePendingRequest(pendingRequest);
             }
         }
 
@@ -110,7 +115,7 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
 
         while (!inFlight.isEmpty()) {
             monitoringModule.incrementFailedHttpRequests();
-            inFlight.pollFirst().release();
+            completePendingRequest(inFlight.pollFirst());
         }
     }
 
@@ -133,19 +138,28 @@ class RequestAndResponseHandler extends ChannelDuplexHandler {
                     TimeUnit.MILLISECONDS
             );
         } else {
-            pendingRequest.release();
+            completePendingRequest(pendingRequest);
         }
     }
 
     private void resend(ChannelHandlerContext ctx, PendingRequest pendingRequest) {
         if (!ctx.channel().isActive()) {
             monitoringModule.incrementFailedHttpRequests();
-            pendingRequest.release();
+            completePendingRequest(pendingRequest);
             return;
         }
 
         resending = pendingRequest;
         ctx.channel().writeAndFlush(pendingRequest.request.retainedDuplicate());
+    }
+
+    int outstandingRequests() {
+        return outstandingRequests;
+    }
+
+    private void completePendingRequest(PendingRequest pendingRequest) {
+        outstandingRequests--;
+        pendingRequest.release();
     }
 
     private static boolean isRetriable(HttpResponseStatus status) {

--- a/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/stats/StandardMonitoringModule.java
@@ -42,6 +42,10 @@ public class StandardMonitoringModule implements MonitoringModule {
         droppedPuts.incrementAndGet();
     }
 
+    public long getDroppedPuts() {
+        return droppedPuts.get();
+    }
+
     @Override
     public void incrementDroppedPuts(Throwable throwable) {
         incrementDroppedPuts();

--- a/core/src/test/java/pl/tkowalcz/tjahzi/LogBufferAgentTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/LogBufferAgentTest.java
@@ -63,7 +63,8 @@ class LogBufferAgentTest {
                         logBuffer,
                         Map.of(),
                         outputBuffer
-                )
+                ),
+                new StandardMonitoringModule()
         );
 
         for (int i = 0; i < 100; i++) {
@@ -116,7 +117,8 @@ class LogBufferAgentTest {
                         logBuffer,
                         Map.of(),
                         outputBuffer
-                )
+                ),
+                new StandardMonitoringModule()
         );
 
         logger.log(
@@ -157,7 +159,8 @@ class LogBufferAgentTest {
                         logBuffer,
                         Map.of(),
                         outputBuffer
-                )
+                ),
+                new StandardMonitoringModule()
         );
 
         // When
@@ -204,7 +207,8 @@ class LogBufferAgentTest {
                         logBuffer,
                         Map.of(),
                         outputBuffer
-                )
+                ),
+                new StandardMonitoringModule()
         );
 
         // When
@@ -262,7 +266,8 @@ class LogBufferAgentTest {
                         logBuffer,
                         Map.of(),
                         outputBuffer
-                )
+                ),
+                new StandardMonitoringModule()
         );
 
         for (int i = 0; i < LogShipperAgent.MAX_MESSAGES_TO_RETRIEVE * 2 + 1; i++) {
@@ -280,6 +285,60 @@ class LogBufferAgentTest {
 
         // Then - three batches of (100, 100, 1) messages and no trailing empty push
         verify(httpClient, times(3)).log((OutputBuffer) any());
+        assertThat(logBuffer.size()).isZero();
+    }
+
+    @Test
+    void shouldCountMessagesAbandonedWhenShutdownDeadlineIsExceeded() throws IOException {
+        // Given
+        ManyToOneRingBuffer logBuffer = new ManyToOneRingBuffer(
+                new UnsafeBuffer(
+                        ByteBuffer.allocateDirect(64 * 1024 + RingBufferDescriptor.TRAILER_LENGTH)
+                )
+        );
+
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        TjahziLogger logger = new TjahziLogger(logBuffer, monitoringModule);
+
+        NettyHttpClient httpClient = mock(NettyHttpClient.class);
+        SettableClock clock = new SettableClock();
+
+        OutputBuffer outputBuffer = new OutputBuffer(PooledByteBufAllocator.DEFAULT.buffer());
+        LogShipperAgent agent = new LogShipperAgent(
+                new TimeCappedBatchingStrategy(
+                        clock,
+                        outputBuffer,
+                        Integer.MAX_VALUE,
+                        Integer.MAX_VALUE,
+                        0
+                ),
+                logBuffer,
+                outputBuffer,
+                httpClient,
+                new LogBufferMessageHandler(
+                        logBuffer,
+                        Map.of(),
+                        outputBuffer
+                ),
+                monitoringModule
+        );
+
+        for (int i = 0; i < LogShipperAgent.MAX_MESSAGES_TO_RETRIEVE * 2 + 1; i++) {
+            logger.log(
+                    42L,
+                    0,
+                    LabelSerializerCreator.from(Map.of()),
+                    new LabelSerializer(),
+                    ByteBuffer.wrap("Test".getBytes())
+            );
+        }
+
+        // When - shutdown timeout of zero allows only a single drain iteration
+        agent.onClose();
+
+        // Then - 100 messages went out, the remaining 101 were abandoned but counted
+        verify(httpClient, times(1)).log((OutputBuffer) any());
+        assertThat(monitoringModule.getDroppedPuts()).isEqualTo(101);
         assertThat(logBuffer.size()).isZero();
     }
 }

--- a/core/src/test/java/pl/tkowalcz/tjahzi/LogBufferAgentTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/LogBufferAgentTest.java
@@ -278,8 +278,8 @@ class LogBufferAgentTest {
         // When
         agent.onClose();
 
-        // Then
-        verify(httpClient, times(4)).log((OutputBuffer) any());
+        // Then - three batches of (100, 100, 1) messages and no trailing empty push
+        verify(httpClient, times(3)).log((OutputBuffer) any());
         assertThat(logBuffer.size()).isZero();
     }
 }

--- a/core/src/test/java/pl/tkowalcz/tjahzi/ShutdownFlushTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/ShutdownFlushTest.java
@@ -1,0 +1,109 @@
+package pl.tkowalcz.tjahzi;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.tkowalcz.tjahzi.http.ClientConfiguration;
+import pl.tkowalcz.tjahzi.http.HttpClientFactory;
+import pl.tkowalcz.tjahzi.http.NettyHttpClient;
+import pl.tkowalcz.tjahzi.stats.StandardMonitoringModule;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+class ShutdownFlushTest {
+
+    private WireMockServer wireMockServer;
+
+    private TjahziInitializer initializer;
+    private StandardMonitoringModule monitoringModule;
+
+    private LabelSerializer labelSerializer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(
+                wireMockConfig().dynamicPort()
+        );
+
+        wireMockServer.start();
+
+        initializer = new TjahziInitializer();
+        monitoringModule = new StandardMonitoringModule();
+
+        labelSerializer = LabelSerializerCreator.from("level", "warn");
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void shouldDeliverLastBatchBeforeCloseReturns() {
+        // Given
+        wireMockServer.stubFor(
+                post(urlEqualTo("/loki/api/v1/push"))
+                        .willReturn(
+                                aResponse().withStatus(204)
+                        ));
+
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .withConnectionTimeoutMillis(10_000)
+                .withHost("localhost")
+                .withPort(wireMockServer.port())
+                .withMaxRetries(1)
+                .build();
+
+        NettyHttpClient httpClient = HttpClientFactory.defaultFactory()
+                .getHttpClient(
+                        clientConfiguration,
+                        monitoringModule
+                );
+
+        // Batch thresholds high enough that nothing is sent until shutdown -
+        // the message below can only arrive through the close-time flush.
+        LoggingSystem loggingSystem = initializer.createLoggingSystem(
+                httpClient,
+                monitoringModule,
+                Map.of(),
+                100 * 1024 * 1024,
+                TimeUnit.HOURS.toMillis(1),
+                1024 * 1024,
+                250,
+                10_000,
+                false
+        );
+        loggingSystem.start();
+
+        TjahziLogger logger = loggingSystem.createLogger();
+        logger.log(
+                System.currentTimeMillis(),
+                0,
+                labelSerializer,
+                new LabelSerializer(),
+                ByteBuffer.wrap("Do not lose me".getBytes())
+        );
+
+        // When
+        loggingSystem.close(
+                (int) TimeUnit.SECONDS.toMillis(10),
+                System.out::println
+        );
+
+        // Then - no awaiting: delivery must have been acknowledged before close returned
+        wireMockServer.verify(
+                1,
+                postRequestedFor(urlMatching("/loki/api/v1/push"))
+        );
+    }
+}

--- a/core/src/test/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandlerTest.java
+++ b/core/src/test/java/pl/tkowalcz/tjahzi/http/RequestAndResponseHandlerTest.java
@@ -62,6 +62,43 @@ class RequestAndResponseHandlerTest {
     }
 
     @Test
+    void shouldTrackOutstandingRequestsAcrossLifecycle() {
+        // Given
+        StandardMonitoringModule monitoringModule = new StandardMonitoringModule();
+        EmbeddedChannel channel = createChannel(monitoringModule, 10_000, 0);
+        RequestAndResponseHandler handler = channel.pipeline().get(RequestAndResponseHandler.class);
+
+        assertThat(handler.outstandingRequests()).isEqualTo(0);
+
+        // When - request written
+        channel.writeOneOutbound(createRequest());
+        channel.flush();
+        drainOutbound(channel);
+
+        // Then
+        assertThat(handler.outstandingRequests()).isEqualTo(1);
+
+        // When - acknowledged
+        channel.writeOneInbound(createResponse(HttpResponseStatus.NO_CONTENT));
+        channel.flush();
+
+        // Then
+        assertThat(handler.outstandingRequests()).isEqualTo(0);
+
+        // When - another request in flight while the channel dies
+        channel.writeOneOutbound(createRequest());
+        channel.flush();
+        drainOutbound(channel);
+        assertThat(handler.outstandingRequests()).isEqualTo(1);
+
+        channel.close();
+
+        // Then
+        assertThat(handler.outstandingRequests()).isEqualTo(0);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
     void shouldRetryRequestAfterServerError() {
         // Given
         StandardMonitoringModule monitoringModule = new StandardMonitoringModule();


### PR DESCRIPTION
Follow-up to #168/#169 — closes the shutdown-loss gap behind the historical reports in #99, #132 and #146.

## Problem

The final flush was fire-and-forget: `onClose()` handed the last batch to the Netty event loop and `close()` returned without awaiting the write, the response, or `shutdownGracefully()` (which was never awaited at all). In production the JVM exits right after `close()` returns — the worker is a daemon thread — killing the event loop with the tail batch still queued. The existing shutdown tests couldn't catch this: the test JVM stays alive after close and polls Loki, so the unawaited background flush always completed.

## Changes

- `RequestAndResponseHandler` tracks an outstanding-request count (volatile, event-loop-confined writes — no hot-path synchronization).
- `HttpConnection.close(timeout)` waits, bounded by the shutdown budget: a marker task ensures queued writes have registered, then outstanding requests are awaited until acknowledged (or the channel dies / deadline passes), then the event loop is shut down gracefully **and awaited**.
- `LoggingSystem.close` passes the remaining shutdown budget through (1s floor so the final handoff is never cut to zero).
- The drain loop no longer sends an empty push on every shutdown (`getBytesPending() > 0` guard); `LogBufferAgentTest` had codified the empty push and was corrected from 4 to 3 expected requests.
- Messages still in the ring buffer when the shutdown deadline expires are now counted into `droppedPuts` (new `StandardMonitoringModule.getDroppedPuts()`), so a lossy shutdown is visible in monitoring instead of silent.

## Tests

- `ShutdownFlushTest.shouldDeliverLastBatchBeforeCloseReturns` — batch thresholds prevent any early send; one message, `close()`, then WireMock verified **immediately with zero polling**. This test fails on master today and distinguishes "delivered before close returned" from "delivered later by a thread production would have killed". It also caught the empty-push bug on its first run.
- `shouldTrackOutstandingRequestsAcrossLifecycle` — counter through write → ack → channel death.
- `shouldCountMessagesAbandonedWhenShutdownDeadlineIsExceeded` — 201 messages, zero budget: 100 ship, 101 counted dropped.

Known limit: nothing can help when `close()` is never invoked (daemon threads + framework exiting without stopping the logging system) — inherent to the `useDaemonThreads` trade-off from #99.
