### PR TITLE
Delay Netty initialization in logback appender until first log event

### DIFF
--- a/core/src/main/java/pl/tkowalcz/tjahzi/stats/MutableMonitoringModuleWrapper.java
+++ b/core/src/main/java/pl/tkowalcz/tjahzi/stats/MutableMonitoringModuleWrapper.java
@@ -70,6 +70,8 @@ public class MutableMonitoringModuleWrapper implements MonitoringModule {
 
     @Override
     public void onClose() {
-        monitoringModule.onClose();
+        if (monitoringModule != null) {
+            monitoringModule.onClose();
+        }
     }
 }

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
@@ -24,10 +24,11 @@ public class LokiAppender extends LokiAppenderConfigurator {
     private EfficientPatternLayout efficientLayout;
     private PatternLayoutEncoder encoder;
 
-    private LoggingSystem loggingSystem;
+    private LokiAppenderFactory lokiAppenderFactory;
+    private volatile LoggingSystem loggingSystem;
     private Function<ILoggingEvent, ByteBuffer> actualEncoder;
 
-    private TjahziLogger logger;
+    private volatile TjahziLogger logger;
     private String logLevelLabel;
     private String loggerNameLabel;
     private String threadNameLabel;
@@ -62,11 +63,24 @@ public class LokiAppender extends LokiAppenderConfigurator {
 
     // @VisibleForTesting
     public LoggingSystem getLoggingSystem() {
+        if (loggingSystem == null) {
+            ensureInitialized();
+        }
+
+        return loggingSystem;
+    }
+
+    // @VisibleForTesting
+    LoggingSystem peekLoggingSystem() {
         return loggingSystem;
     }
 
     @Override
     protected void append(ILoggingEvent event) {
+        if (logger == null) {
+            ensureInitialized();
+        }
+
         String logLevel = event.getLevel().toString();
         String loggerName = event.getLoggerName();
         String threadName = event.getThreadName();
@@ -170,8 +184,11 @@ public class LokiAppender extends LokiAppenderConfigurator {
             actualEncoder = event -> ByteBuffer.wrap(encoder.encode(event));
         }
 
-        LokiAppenderFactory lokiAppenderFactory = new LokiAppenderFactory(this);
-        loggingSystem = lokiAppenderFactory.createAppender();
+        // Configuration is validated and labels extracted eagerly - only the
+        // networking stack is deferred. Creating the Netty client here would
+        // emit SLF4J calls while logback (the SLF4J backend) is still
+        // initializing, causing the substitute logger replay warnings.
+        lokiAppenderFactory = new LokiAppenderFactory(this);
         logLevelLabel = lokiAppenderFactory.getLogLevelLabel();
         loggerNameLabel = lokiAppenderFactory.getLoggerNameLabel();
         threadNameLabel = lokiAppenderFactory.getThreadNameLabel();
@@ -179,9 +196,17 @@ public class LokiAppender extends LokiAppenderConfigurator {
         structuredMetadata = lokiAppenderFactory.getStructuredMetadata();
         monitoringModuleWrapper = lokiAppenderFactory.getMonitoringModuleWrapper();
 
-        logger = loggingSystem.createLogger();
-        loggingSystem.start();
         super.start();
+    }
+
+    private synchronized void ensureInitialized() {
+        if (logger != null) {
+            return;
+        }
+
+        loggingSystem = lokiAppenderFactory.createAppender();
+        loggingSystem.start();
+        logger = loggingSystem.createLogger();
     }
 
     @Override

--- a/logback-appender/src/test/java/pl/tkowalcz/tjahzi/logback/LazyNetworkingInitializationTest.java
+++ b/logback-appender/src/test/java/pl/tkowalcz/tjahzi/logback/LazyNetworkingInitializationTest.java
@@ -1,0 +1,69 @@
+package pl.tkowalcz.tjahzi.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.tkowalcz.tjahzi.logback.infra.TestUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.tkowalcz.tjahzi.logback.infra.IntegrationTest.loadConfig;
+
+class LazyNetworkingInitializationTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty("loki.host", "localhost");
+        System.setProperty("loki.port", "42390");
+    }
+
+    @Test
+    void shouldNotInitializeNetworkingUntilFirstAppend() {
+        // When - configuration loads and the appender starts. This is the phase
+        // that runs inside SLF4J initialization in real applications, so no
+        // Netty (and hence no SLF4J re-entrant logging) may happen here.
+        LoggerContext context = loadConfig("appender-test-with-buffer-size-megabytes-unset.xml");
+        LokiAppender loki = TestUtil.getLokiAppender(context);
+
+        // Then
+        assertThat(loki.isStarted()).isTrue();
+        assertThat(loki.peekLoggingSystem()).isNull();
+
+        // When - the first log event flows through the appender
+        context.getLogger(LazyNetworkingInitializationTest.class).info("first message");
+
+        // Then
+        assertThat(loki.peekLoggingSystem()).isNotNull();
+
+        context.stop();
+    }
+
+    @Test
+    void shouldInitializeNetworkingWhenLoggingSystemIsAccessedDirectly() {
+        // Given
+        LoggerContext context = loadConfig("appender-test-with-buffer-size-megabytes-unset.xml");
+        LokiAppender loki = TestUtil.getLokiAppender(context);
+
+        // When - tests and monitoring hooks access the logging system directly
+        // without any event having been logged
+        long bufferSize = loki.getLoggingSystem().getLogBufferSize();
+
+        // Then
+        assertThat(bufferSize).isEqualTo(32 * 1024 * 1024);
+
+        context.stop();
+    }
+
+    @Test
+    void shouldStopCleanlyWhenNoEventWasEverLogged() {
+        // Given
+        LoggerContext context = loadConfig("appender-test-with-buffer-size-megabytes-unset.xml");
+        LokiAppender loki = TestUtil.getLokiAppender(context);
+
+        // When - context stops before any append; must not throw and must not
+        // boot the networking stack just to shut it down
+        context.stop();
+
+        // Then
+        assertThat(loki.peekLoggingSystem()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes #93.

`LokiAppender.start()` runs inside logback configuration — which in real applications executes during SLF4J's own initialization. Booting Netty at that point makes Netty acquire its internal loggers through SLF4J *re-entrantly*, so those calls get captured by SLF4J's substitute-logger mechanism and replayed afterwards, producing the reported warning ("A number (57) of logging calls during the initialization phase have been intercepted and are now being replayed"). Harmless but alarming, and logback-specific since logback is the SLF4J backend being initialized.

This revives the never-merged `93-delay-netty-init-logback` branch, rebased onto current master:

- `start()` still eagerly validates configuration and extracts labels/metadata — misconfiguration is caught at startup exactly as before. Only `createAppender()` (the Netty boot) is deferred to the first `append()`, by which time SLF4J initialization is long finished.
- Synchronized one-time init with volatile publication; steady-state cost is a single volatile null-check per append.
- Stopping a context that never logged anything is a clean no-op — it does not boot the network stack just to shut it down. This surfaced a latent NPE in `MutableMonitoringModuleWrapper.onClose()`, now null-guarded.

Trade-off accepted: connection problems surface asynchronously at first log call rather than at appender start (connect was always async anyway; only the event-loop creation moved).

Tests: new `LazyNetworkingInitializationTest` (no networking after start, init on first append, lazy init via direct `getLoggingSystem()` access, clean stop without any event) plus the existing end-to-end container tests confirming delivery still works.
