### PR TITLE
Fix flaky fragmentation test: disable Loki level discovery in test configs

### DIFF
--- a/core/src/test/resources/loki-config.yaml
+++ b/core/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/log4j2-appender/src/test/resources/loki-config.yaml
+++ b/log4j2-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/logback-appender/src/test/resources/loki-config.yaml
+++ b/logback-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/reload4j-appender/src/test/resources/loki-config.yaml
+++ b/reload4j-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: false
+  discover_log_levels: false


### PR DESCRIPTION
Second (and primary) root cause of the intermittent `LogLineFragmentationTest.shouldFragmentMessageOverLimit` failures — the earlier #178 fixed a real isolation leak, but the failure recurred on a branch that already contained it.

**Mechanism, verified against a real `grafana/loki:3.1.0`:** Loki's level discovery scans each line for level keywords and attaches `detected_level` as structured metadata, which the query API folds into the stream label set. A 110KB `RandomStringUtils.randomAlphanumeric` payload has a non-trivial chance of containing a literal `info`/`Info`/`INFO`/`ERROR`/… substring (case-variant `contains`, no word boundaries — an embedded `xxxERRORxxx` triggers it). When one random line matches and the others don't, the query result splits into two streams and `data.result.size() == 1` fails. Reproduced and confirmed: with the current test config an embedded keyword yields 2 streams; with `discover_log_levels: false` it yields 1.

Fix: `discover_log_levels: false` in all four modules' test `loki-config.yaml`. Tests assert on tjahzi-controlled labels only, so discovery adds nothing but nondeterminism.

Test-config only, no production code.
