### PR TITLE
[0.9.x] Fix flaky fragmentation test: disable Loki level discovery in test configs

### DIFF
--- a/core/src/test/resources/loki-config.yaml
+++ b/core/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/log4j2-appender/src/test/resources/loki-config.yaml
+++ b/log4j2-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/logback-appender/src/test/resources/loki-config.yaml
+++ b/logback-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: false

--- a/reload4j-appender/src/test/resources/loki-config.yaml
+++ b/reload4j-appender/src/test/resources/loki-config.yaml
@@ -28,3 +28,4 @@ storage_config:
 
 limits_config:
   allow_structured_metadata: false
+  discover_log_levels: false


### PR DESCRIPTION
Backport (clean cherry-pick). See master PR for the verified root cause.
