### PR TITLE
Update Netty to 4.1.135.Final (12 advisories, incl. CVE-2026-42584, CVE-2026-50010)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.131.Final</version>
+            <version>4.1.135.Final</version>
         </dependency>
 
         <!-- For the example metric consumer -->


### PR DESCRIPTION
Runtime-dependency CVE scan (OSV.dev over `dependency:list -DincludeScope=runtime`) found Netty 4.1.131.Final affected by 12 advisories, 6 HIGH. Most relevant to tjahzi as an HTTP client: `HttpClientCodec` response desynchronization (CVE-2026-42584) and trust-manager wrapping silently disabling hostname verification (CVE-2026-50010, relevant to the `useSSL`/truststore path). All fixed in **4.1.135.Final** — same Java 8-compatible 4.1 line, drop-in bump of the single `netty-codec-http` declaration.

Verified: 4.1.135.Final has zero OSV-known vulnerabilities across all pulled modules; 21 HTTP-layer tests green locally (handler retry/timeout suite, shutdown flush, headers, reconnect, resource cleanup); shaded nodep jar builds and relocates the new version. Agrona 1.22.0 and the rest of the runtime surface scanned clean.

Also worth noting: the `-nodep` jars shade Netty, so the published fat jars physically contained the flagged classes — this bump cleans those too.
