### PR TITLE
[0.9.x] Update Netty to 4.1.135.Final

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.131.Final</version>
+            <version>4.1.135.Final</version>
         </dependency>
 
         <!-- For the example metric consumer -->


### PR DESCRIPTION
Backport (clean cherry-pick) — 4.1.135 stays Java 8 compatible. See master PR for the advisory list and verification. Should go into 0.9.43.
