### PR TITLE
Fix two lazy-init regressions: monitoring module clobber and Netty bootstrap recursion

### DIFF
--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
@@ -25,6 +25,7 @@ public class LokiAppender extends LokiAppenderConfigurator {
     private PatternLayoutEncoder encoder;
 
     private LokiAppenderFactory lokiAppenderFactory;
+    private boolean initializing;
     private volatile LoggingSystem loggingSystem;
     private Function<ILoggingEvent, ByteBuffer> actualEncoder;
 
@@ -79,6 +80,15 @@ public class LokiAppender extends LokiAppenderConfigurator {
     protected void append(ILoggingEvent event) {
         if (logger == null) {
             ensureInitialized();
+
+            if (logger == null) {
+                // Recursive append from the thread that is currently starting
+                // the networking stack (e.g. Netty logging its own bootstrap
+                // through this appender). Delivering it is impossible - count
+                // it instead of recursing into initialization.
+                monitoringModuleWrapper.incrementDroppedPuts();
+                return;
+            }
         }
 
         String logLevel = event.getLevel().toString();
@@ -200,13 +210,18 @@ public class LokiAppender extends LokiAppenderConfigurator {
     }
 
     private synchronized void ensureInitialized() {
-        if (logger != null) {
+        if (logger != null || initializing) {
             return;
         }
 
-        loggingSystem = lokiAppenderFactory.createAppender();
-        loggingSystem.start();
-        logger = loggingSystem.createLogger();
+        initializing = true;
+        try {
+            loggingSystem = lokiAppenderFactory.createAppender();
+            loggingSystem.start();
+            logger = loggingSystem.createLogger();
+        } finally {
+            initializing = false;
+        }
     }
 
     @Override

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
@@ -54,7 +54,16 @@ public class LokiAppenderFactory {
 
         structuredMetadata = structuredMetadataFactory.convertLabelsDroppingInvalid();
         mdcLogLabels = validateMdcLogLabels(configurator);
+
+        // Install the default monitoring module eagerly - createAppender() runs
+        // lazily on first append and must not overwrite a module the user
+        // injected via setMonitoringModule() after start.
         monitoringModuleWrapper = new MutableMonitoringModuleWrapper();
+        if (configurator.isVerbose()) {
+            monitoringModuleWrapper.setMonitoringModule(new LoggingMonitoringModule(configurator::addError));
+        } else {
+            monitoringModuleWrapper.setMonitoringModule(new StandardMonitoringModule());
+        }
     }
 
     private static List<String> validateMdcLogLabels(LokiAppenderConfigurator configurator) {
@@ -94,12 +103,6 @@ public class LokiAppenderFactory {
         String[] additionalHeaders = configurator.getHeaders().stream()
                 .flatMap(header -> Stream.of(header.getName(), header.getValue()))
                 .toArray(String[]::new);
-
-        if (configurator.isVerbose()) {
-            monitoringModuleWrapper.setMonitoringModule(new LoggingMonitoringModule(configurator::addError));
-        } else {
-            monitoringModuleWrapper.setMonitoringModule(new StandardMonitoringModule());
-        }
 
         NettyHttpClient httpClient = HttpClientFactory
                 .defaultFactory()


### PR DESCRIPTION
Root-caused from the `LokiAppenderMonitoringTest.shouldInjectMonitoringAndUseIt` failure on the #188 branch (first CI run containing merged #184). Two distinct regressions from the lazy Netty initialization:

1. **Monitoring module clobber (the CI failure, deterministic):** `createAppender()` unconditionally installs the default monitoring module. Pre-#184 that ran in `start()`, before any user `setMonitoringModule()` call; post-#184 it runs at first append — wiping a module injected in between. Moved the default installation to the factory constructor (eager), restoring the exact old ordering.

2. **Class-init recursion (order-dependent):** when a logback config routes `io.netty` at DEBUG to the Loki appender (several test configs do via `root level="debug"`), Netty's static initializers log during bootstrap → re-enter `append()` on the same thread → re-enter `createAppender()` → re-enter the still-initializing `PlatformDependent$Mpsc` → `NoClassDefFoundError`. Reproduced locally; the failure appears/disappears depending on which test initializes Netty first, which is why it slipped past #184's review. `ensureInitialized()` now has a reentrancy guard; events logged by the initializing thread are counted via `incrementDroppedPuts()` (a handful of Netty bootstrap debug lines at most) instead of recursing.

Both have existing tests that now pass: `LokiAppenderMonitoringTest` (bug 1) and `LazyNetworkingInitializationTest`, which reproduced the recursion NPE locally (bug 2). Full affected suite green locally including the end-to-end container tests.

Note: #188/#189 (Netty bump) failed CI only because of bug 1 — after this merges they need a rerun/rebase.
