### PR TITLE
[0.9.x] Fix two lazy-init regressions: monitoring module clobber and Netty bootstrap recursion

### DIFF
--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppender.java
@@ -25,6 +25,7 @@ public class LokiAppender extends LokiAppenderConfigurator {
     private PatternLayoutEncoder encoder;
 
     private LokiAppenderFactory lokiAppenderFactory;
+    private boolean initializing;
     private volatile LoggingSystem loggingSystem;
     private Function<ILoggingEvent, ByteBuffer> actualEncoder;
 
@@ -79,6 +80,15 @@ public class LokiAppender extends LokiAppenderConfigurator {
     protected void append(ILoggingEvent event) {
         if (logger == null) {
             ensureInitialized();
+
+            if (logger == null) {
+                // Recursive append from the thread that is currently starting
+                // the networking stack (e.g. Netty logging its own bootstrap
+                // through this appender). Delivering it is impossible - count
+                // it instead of recursing into initialization.
+                monitoringModuleWrapper.incrementDroppedPuts();
+                return;
+            }
         }
 
         String logLevel = event.getLevel().toString();
@@ -200,13 +210,18 @@ public class LokiAppender extends LokiAppenderConfigurator {
     }
 
     private synchronized void ensureInitialized() {
-        if (logger != null) {
+        if (logger != null || initializing) {
             return;
         }
 
-        loggingSystem = lokiAppenderFactory.createAppender();
-        loggingSystem.start();
-        logger = loggingSystem.createLogger();
+        initializing = true;
+        try {
+            loggingSystem = lokiAppenderFactory.createAppender();
+            loggingSystem.start();
+            logger = loggingSystem.createLogger();
+        } finally {
+            initializing = false;
+        }
     }
 
     @Override

--- a/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
+++ b/logback-appender/src/main/java/pl/tkowalcz/tjahzi/logback/LokiAppenderFactory.java
@@ -54,7 +54,16 @@ public class LokiAppenderFactory {
 
         structuredMetadata = structuredMetadataFactory.convertLabelsDroppingInvalid();
         mdcLogLabels = validateMdcLogLabels(configurator);
+
+        // Install the default monitoring module eagerly - createAppender() runs
+        // lazily on first append and must not overwrite a module the user
+        // injected via setMonitoringModule() after start.
         monitoringModuleWrapper = new MutableMonitoringModuleWrapper();
+        if (configurator.isVerbose()) {
+            monitoringModuleWrapper.setMonitoringModule(new LoggingMonitoringModule(configurator::addError));
+        } else {
+            monitoringModuleWrapper.setMonitoringModule(new StandardMonitoringModule());
+        }
     }
 
     private static List<String> validateMdcLogLabels(LokiAppenderConfigurator configurator) {
@@ -94,12 +103,6 @@ public class LokiAppenderFactory {
         String[] additionalHeaders = configurator.getHeaders().stream()
                 .flatMap(header -> Stream.of(header.getName(), header.getValue()))
                 .toArray(String[]::new);
-
-        if (configurator.isVerbose()) {
-            monitoringModuleWrapper.setMonitoringModule(new LoggingMonitoringModule(configurator::addError));
-        } else {
-            monitoringModuleWrapper.setMonitoringModule(new StandardMonitoringModule());
-        }
 
         NettyHttpClient httpClient = HttpClientFactory
                 .defaultFactory()


### PR DESCRIPTION
Backport (clean cherry-pick). See master PR for the analysis of both regressions from the lazy-init change.
